### PR TITLE
Refactor NotDatabase config and improve documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.notmarra</groupId>
     <artifactId>NotLib</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <name>NotLib</name>

--- a/src/main/java/com/notmarra/notlib/database/NotDatabase.java
+++ b/src/main/java/com/notmarra/notlib/database/NotDatabase.java
@@ -28,26 +28,31 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 /**
  * @class NotDatabase
- * @brief An abstract base class for database operations with configurable settings.
+ * @brief An abstract base class for database operations with configurable
+ *        settings.
  * 
- * NotDatabase provides a foundation for database interactions with built-in connection pooling via HikariCP.
- * It supports common SQL operations including select, insert, update, and delete operations through
- * a fluent SQL builder interface.
+ *        NotDatabase provides a foundation for database interactions with
+ *        built-in connection pooling via HikariCP.
+ *        It supports common SQL operations including select, insert, update,
+ *        and delete operations through
+ *        a fluent SQL builder interface.
  * 
  * @extends NotConfigurable
  * 
  * @details The class manages database connections and provides methods for:
- *   - Connection management via HikariCP
- *   - Table creation and management
- *   - SQL query execution
- *   - Data type conversion
- *   - Configuration handling
+ *          - Connection management via HikariCP
+ *          - Table creation and management
+ *          - SQL query execution
+ *          - Data type conversion
+ *          - Configuration handling
  * 
- * Implementations must provide database-specific logic for connecting, creating tables, and inserting data.
+ *          Implementations must provide database-specific logic for connecting,
+ *          creating tables, and inserting data.
  * 
  */
 public abstract class NotDatabase extends NotConfigurable {
     private final String defaultConfig;
+    private String customId;
     protected HikariDataSource source;
     private NotSqlQueryExecutor queryExecutor;
     private Map<String, NotTable> tables = new HashMap<>();
@@ -58,11 +63,27 @@ public abstract class NotDatabase extends NotConfigurable {
         this.queryExecutor = new NotSqlQueryExecutor(this);
     }
 
+    public void setCustomId(String id) {
+        this.customId = id;
+    }
+
+    public String getId() {
+        if (customId != null)
+            return customId;
+
+        ConfigurationSection config = getDatabaseConfig();
+        String configId = config.getString("databaseId");
+        if (configId != null)
+            return configId;
+
+        return plugin.getName();
+    }
+
     @Override
-    public List<String> getConfigPaths() { return List.of(defaultConfig); }
-    
-    public abstract String getId();
-    
+    public List<String> getConfigPaths() {
+        return List.of(defaultConfig);
+    }
+
     public abstract List<NotTable> setupTables();
 
     public abstract void connect();
@@ -71,27 +92,62 @@ public abstract class NotDatabase extends NotConfigurable {
 
     public abstract boolean insertRow(NotTable table, List<Object> row);
 
-    public NotSqlBuilder select(String table) { return NotSqlBuilder.select(table); }
-    public NotSqlBuilder select(String table, List<String> columns) { return NotSqlBuilder.select(table, columns); }
-    public NotSqlBuilder insertInto(String table) { return NotSqlBuilder.insertInto(table); }
-    public NotSqlBuilder update(String table) { return NotSqlBuilder.update(table); }
-    public NotSqlBuilder deleteFrom(String table) { return NotSqlBuilder.deleteFrom(table); }
-    public boolean exists(NotSqlBuilder builder) { return queryExecutor.exists(builder); }
-    public NotRecord selectOne(NotSqlBuilder builder) { return queryExecutor.selectOne(builder); }
-    public List<NotRecord> select(NotSqlBuilder builder) { return queryExecutor.select(builder); }
-    public int execute(NotSqlBuilder builder) { return queryExecutor.update(builder); }
+    public NotSqlBuilder select(String table) {
+        return NotSqlBuilder.select(table);
+    }
 
-    public NotSqlQueryExecutor getQueryExecutor() { return queryExecutor; }
+    public NotSqlBuilder select(String table, List<String> columns) {
+        return NotSqlBuilder.select(table, columns);
+    }
 
-    public Map<String, NotTable> getTables() { return tables; }
-    public NotTable getTable(String tableName) { return tables.get(tableName); }
+    public NotSqlBuilder insertInto(String table) {
+        return NotSqlBuilder.insertInto(table);
+    }
+
+    public NotSqlBuilder update(String table) {
+        return NotSqlBuilder.update(table);
+    }
+
+    public NotSqlBuilder deleteFrom(String table) {
+        return NotSqlBuilder.deleteFrom(table);
+    }
+
+    public boolean exists(NotSqlBuilder builder) {
+        return queryExecutor.exists(builder);
+    }
+
+    public NotRecord selectOne(NotSqlBuilder builder) {
+        return queryExecutor.selectOne(builder);
+    }
+
+    public List<NotRecord> select(NotSqlBuilder builder) {
+        return queryExecutor.select(builder);
+    }
+
+    public int execute(NotSqlBuilder builder) {
+        return queryExecutor.update(builder);
+    }
+
+    public NotSqlQueryExecutor getQueryExecutor() {
+        return queryExecutor;
+    }
+
+    public Map<String, NotTable> getTables() {
+        return tables;
+    }
+
+    public NotTable getTable(String tableName) {
+        return tables.get(tableName);
+    }
 
     /**
      * @brief Initializes the database by setting up all tables.
      * 
-     * This method retrieves all tables that need to be set up, sets their database context,
-     * creates the database structures for each table, and stores them in the tables map
-     * indexed by their names.
+     *        This method retrieves all tables that need to be set up, sets their
+     *        database context,
+     *        creates the database structures for each table, and stores them in the
+     *        tables map
+     *        indexed by their names.
      */
     public void setup() {
         for (NotTable table : setupTables()) {
@@ -100,12 +156,14 @@ public abstract class NotDatabase extends NotConfigurable {
             tables.put(table.getName(), table);
         }
     }
-    
+
     /**
      * @brief Handles the configuration reload event.
      * 
-     * This method is called when configurations are reloaded. It closes the current database
-     * connection and establishes a new connection to reflect any changes in the configuration.
+     *        This method is called when configurations are reloaded. It closes the
+     *        current database
+     *        connection and establishes a new connection to reflect any changes in
+     *        the configuration.
      * 
      * @param reloadedConfigs List of configuration files that were reloaded
      */
@@ -118,32 +176,37 @@ public abstract class NotDatabase extends NotConfigurable {
     /**
      * @brief Retrieves the database-specific configuration section.
      * 
-     * This method gets the configuration section from the main configuration file
-     * that is specific to this database instance. The section is identified by
-     * "database.[database_id]" where [database_id] is the ID returned by getId().
+     *        This method gets the configuration section from the main configuration
+     *        file
+     *        that is specific to this database instance. The section is identified
+     *        by
+     *        "database.[database_id]" where [database_id] is the ID returned by
+     *        getId().
      * 
      * @return ConfigurationSection containing database-specific configuration.
-     * If the section doesn't exist, returns an empty YamlConfiguration.
+     *         If the section doesn't exist, returns an empty YamlConfiguration.
      */
     public ConfigurationSection getDatabaseConfig() {
         FileConfiguration config = getConfig(getConfigPaths().get(0));
-        ConfigurationSection section = config.getConfigurationSection("database." + getId());
-        if (section == null) return new YamlConfiguration();
-        return section;
+        ConfigurationSection section = config.getConfigurationSection("data");
+        return (section == null) ? new YamlConfiguration() : section;
     }
-    
+
     /**
      * Sets the data source for the database.
      *
      * @param source The HikariDataSource to be used for database connections
      */
-    public void setSource(HikariDataSource source) { this.source = source; }
-    
+    public void setSource(HikariDataSource source) {
+        this.source = source;
+    }
+
     /**
      * @brief Retrieves a connection from the underlying DataSource.
      * 
      * @return A Connection object representing a connection to the database.
-     * @throws SQLException If the DataSource is not initialized, is closed, or if a database access error occurs.
+     * @throws SQLException If the DataSource is not initialized, is closed, or if a
+     *                      database access error occurs.
      */
     public Connection getConnection() throws SQLException {
         if (source == null || source.isClosed()) {
@@ -155,14 +218,16 @@ public abstract class NotDatabase extends NotConfigurable {
     /**
      * Closes the database connection.
      * 
-     * This method safely closes the data source if it exists and is not already closed.
-     * It's recommended to call this method when the database is no longer needed to 
+     * This method safely closes the data source if it exists and is not already
+     * closed.
+     * It's recommended to call this method when the database is no longer needed to
      * release resources and prevent memory leaks.
      * 
      * @see javax.sql.DataSource#close()
      */
     public void close() {
-        if (source != null && !source.isClosed()) source.close();
+        if (source != null && !source.isClosed())
+            source.close();
     }
 
     /**
@@ -174,16 +239,22 @@ public abstract class NotDatabase extends NotConfigurable {
     }
 
     /**
-     * @brief Converts a value to the appropriate Java type based on a SQL column type.
+     * @brief Converts a value to the appropriate Java type based on a SQL column
+     *        type.
      *
-     * This method takes a SQL column type and a value and converts the value to the appropriate Java type
-     * that corresponds to that column type. For example, it converts values for "INT" columns to Integer objects,
-     * values for "FLOAT" columns to Float objects, etc.
+     *        This method takes a SQL column type and a value and converts the value
+     *        to the appropriate Java type
+     *        that corresponds to that column type. For example, it converts values
+     *        for "INT" columns to Integer objects,
+     *        values for "FLOAT" columns to Float objects, etc.
      *
-     * @param columnType The SQL data type of the column (e.g., "TEXT", "INT", "FLOAT")
-     * @param value The value to convert to the appropriate Java type
-     * @return The value converted to the appropriate Java type based on the column type,
-     *         or null if the input value is null. If the column type is not supported,
+     * @param columnType The SQL data type of the column (e.g., "TEXT", "INT",
+     *                   "FLOAT")
+     * @param value      The value to convert to the appropriate Java type
+     * @return The value converted to the appropriate Java type based on the column
+     *         type,
+     *         or null if the input value is null. If the column type is not
+     *         supported,
      *         the value is returned as a String and an error is logged.
      */
     public Object convertValue(String columnType, Object value) {
@@ -223,18 +294,21 @@ public abstract class NotDatabase extends NotConfigurable {
                 return String.valueOf(value);
             default:
                 getLogger().error("Unsupported column type: " + columnType + ". Returning as string.");
-                return String.valueOf(value); 
+                return String.valueOf(value);
+        }
     }
-}
 
     /**
      * @brief Processes a database operation using a provided consumer.
      * 
-     * This method opens a database connection, passes it to the provided consumer for processing,
-     * and ensures the connection is properly closed afterwards. Any exceptions during processing
-     * are caught, logged, and the stack trace is printed.
+     *        This method opens a database connection, passes it to the provided
+     *        consumer for processing,
+     *        and ensures the connection is properly closed afterwards. Any
+     *        exceptions during processing
+     *        are caught, logged, and the stack trace is printed.
      * 
-     * @param consumer A Consumer functional interface that accepts a Connection object to perform
+     * @param consumer A Consumer functional interface that accepts a Connection
+     *                 object to perform
      *                 database operations.
      */
     public void process(Consumer<Connection> consumer) {
@@ -249,13 +323,18 @@ public abstract class NotDatabase extends NotConfigurable {
     /**
      * @brief Executes custom operations on a database statement.
      * 
-     * This method creates a connection and statement, then passes them to the provided consumer 
-     * for custom database operations. The connection is automatically closed after execution.
+     *        This method creates a connection and statement, then passes them to
+     *        the provided consumer
+     *        for custom database operations. The connection is automatically closed
+     *        after execution.
      * 
-     * @param consumer A BiConsumer that accepts a Connection and Statement to perform database operations
+     * @param consumer A BiConsumer that accepts a Connection and Statement to
+     *                 perform database operations
      * 
-     * @note The connection and statement are automatically managed, including proper closing of resources
-     * @note Any exceptions during execution are caught, logged, and printed to stack trace
+     * @note The connection and statement are automatically managed, including
+     *       proper closing of resources
+     * @note Any exceptions during execution are caught, logged, and printed to
+     *       stack trace
      */
     public void processStatement(BiConsumer<Connection, Statement> consumer) {
         try (Connection connection = getConnection()) {
@@ -269,12 +348,17 @@ public abstract class NotDatabase extends NotConfigurable {
     /**
      * @brief Executes a SQL statement that returns a boolean value.
      * 
-     * This method executes the specified SQL statement on the database connection
-     * and returns the boolean result. The SQL statement is debugged if logging is enabled.
+     *        This method executes the specified SQL statement on the database
+     *        connection
+     *        and returns the boolean result. The SQL statement is debugged if
+     *        logging is enabled.
      * 
      * @param sql The SQL statement to execute
-     * @return true if the first result is a ResultSet object; false if it is an update count or there are no results
-     * @throws SQLException if a database access error occurs or the given SQL statement produces a ResultSet object that is then automatically closed
+     * @return true if the first result is a ResultSet object; false if it is an
+     *         update count or there are no results
+     * @throws SQLException if a database access error occurs or the given SQL
+     *                      statement produces a ResultSet object that is then
+     *                      automatically closed
      * @see java.sql.Statement#execute(String)
      */
     public boolean processResult(String sql) {
@@ -292,13 +376,15 @@ public abstract class NotDatabase extends NotConfigurable {
     /**
      * @brief Executes an SQL update statement with the provided parameters.
      * 
-     * This method executes SQL statements that modify the database (INSERT, UPDATE, DELETE).
-     * It logs the SQL statement and parameters for debugging purposes.
+     *        This method executes SQL statements that modify the database (INSERT,
+     *        UPDATE, DELETE).
+     *        It logs the SQL statement and parameters for debugging purposes.
      * 
-     * @param sql The SQL update statement to execute
+     * @param sql    The SQL update statement to execute
      * @param params List of parameters to be set in the prepared statement
      * 
-     * @return The number of rows affected by the SQL statement, or -1 if an error occurs
+     * @return The number of rows affected by the SQL statement, or -1 if an error
+     *         occurs
      * 
      * @throws SQLException Handled internally, errors are logged
      */
@@ -311,11 +397,11 @@ public abstract class NotDatabase extends NotConfigurable {
         try {
             Connection connection = getConnection();
             PreparedStatement stmt = connection.prepareStatement(sql);
-            
+
             for (int i = 0; i < params.size(); i++) {
                 stmt.setObject(i + 1, params.get(i));
             }
-            
+
             return stmt.executeUpdate();
         } catch (SQLException e) {
             getLogger().error("Error processing update: " + e.getMessage());
@@ -325,16 +411,22 @@ public abstract class NotDatabase extends NotConfigurable {
     }
 
     /**
-     * Executes a SELECT SQL query and returns the results as a list of NotRecord objects.
+     * Executes a SELECT SQL query and returns the results as a list of NotRecord
+     * objects.
      * 
-     * This method prepares and executes the provided SQL query with the given parameters.
-     * It processes the ResultSet and converts each row into a NotRecord object with appropriate 
+     * This method prepares and executes the provided SQL query with the given
+     * parameters.
+     * It processes the ResultSet and converts each row into a NotRecord object with
+     * appropriate
      * type conversions for different SQL data types.
      * 
-     * @param sql The SELECT SQL query to execute
-     * @param params List of parameters to bind to the prepared statement. Can be empty if no parameters are needed.
-     * @return A List of NotRecord objects containing the query results. Returns an empty list if an error occurs.
-     * @throws SQLException If a database access error occurs (caught internally and logged)
+     * @param sql    The SELECT SQL query to execute
+     * @param params List of parameters to bind to the prepared statement. Can be
+     *               empty if no parameters are needed.
+     * @return A List of NotRecord objects containing the query results. Returns an
+     *         empty list if an error occurs.
+     * @throws SQLException If a database access error occurs (caught internally and
+     *                      logged)
      */
     public List<NotRecord> processSelect(String sql, List<Object> params) {
         NotLib.dbg().log(NotDebugger.C_DATABASE, "[processSelect] SQL: " + sql);
@@ -343,19 +435,19 @@ public abstract class NotDatabase extends NotConfigurable {
         }
 
         try (Connection connection = getConnection();
-            PreparedStatement stmt = connection.prepareStatement(sql)) {
-            
+                PreparedStatement stmt = connection.prepareStatement(sql)) {
+
             if (params != null) {
                 for (int i = 0; i < params.size(); i++) {
                     stmt.setObject(i + 1, params.get(i));
                 }
             }
-            
+
             try (ResultSet rs = stmt.executeQuery()) {
                 ResultSetMetaData metaData = rs.getMetaData();
                 int columnCount = metaData.getColumnCount();
                 List<NotRecord> resultList = new ArrayList<>();
-                
+
                 while (rs.next()) {
                     Map<String, Object> row = new HashMap<>();
                     for (int i = 1; i <= columnCount; i++) {
@@ -367,7 +459,7 @@ public abstract class NotDatabase extends NotConfigurable {
 
                     resultList.add(new NotRecord(row));
                 }
-                
+
                 return resultList;
             }
         } catch (SQLException e) {

--- a/src/main/java/com/notmarra/notlib/database/source/NotMySQL.java
+++ b/src/main/java/com/notmarra/notlib/database/source/NotMySQL.java
@@ -19,55 +19,64 @@ import com.zaxxer.hikari.HikariDataSource;
 
 /**
  * @class NotMySQL
- * @brief An abstract class for MySQL database implementation using HikariCP connection pooling.
+ * @brief An abstract class for MySQL database implementation using HikariCP
+ *        connection pooling.
  * 
- * This class extends NotDatabase and provides MySQL-specific functionality for database operations.
- * It handles MySQL connection configurations, table creation with appropriate column types,
- * and data insertion operations.
+ *        This class extends NotDatabase and provides MySQL-specific
+ *        functionality for database operations.
+ *        It handles MySQL connection configurations, table creation with
+ *        appropriate column types,
+ *        and data insertion operations.
  * 
- * @note The class uses HikariCP for efficient connection pooling with optimized configurations.
+ * @note The class uses HikariCP for efficient connection pooling with optimized
+ *       configurations.
  * 
  * @see NotDatabase
  */
 public abstract class NotMySQL extends NotDatabase {
-    public static final String ID = "MySQL";
 
-    public NotMySQL(NotPlugin plugin, String defaultConfig) { super(plugin, defaultConfig); }
-
-    @Override
-    public String getId() { return ID; }
+    public NotMySQL(NotPlugin plugin, String defaultConfig) {
+        super(plugin, defaultConfig);
+    }
 
     /**
      * @brief Establishes a connection to a MySQL database using HikariCP.
      * 
-     * This method reads database configuration from the provided configuration section
-     * and sets up a HikariCP connection pool with optimized settings for MySQL.
-     * It configures connection properties, statement caching, and pool size parameters
-     * to ensure efficient database operations.
+     *        This method reads database configuration from the provided
+     *        configuration section
+     *        and sets up a HikariCP connection pool with optimized settings for
+     *        MySQL.
+     *        It configures connection properties, statement caching, and pool size
+     *        parameters
+     *        to ensure efficient database operations.
      * 
-     * The connection uses the following properties from configuration:
-     *   - host: Database server hostname
-     *   - port: Database server port
-     *   - database: Database name
-     *   - username: Database username
-     *   - password: Database password
+     *        The connection uses the following properties from configuration:
+     *        - host: Database server hostname
+     *        - port: Database server port
+     *        - database: Database name
+     *        - username: Database username
+     *        - password: Database password
      * 
      * @note The method initializes the 'source' field with a new HikariDataSource.
      */
     @Override
     public void connect() {
-        ConfigurationSection configSection = getDatabaseConfig();
-        String host = configSection.getString("host");
-        String port = configSection.getString("port");
-        String database = configSection.getString("database");
-        String username = configSection.getString("username");
-        String password = configSection.getString("password");
+        ConfigurationSection config = getDatabaseConfig();
+        ConfigurationSection mysql = config.getConfigurationSection("mysql");
+        if (mysql == null) {
+            throw new IllegalArgumentException("MySQL section in config.yml is null or empty!");
+        }
+        String host = mysql.getString("host");
+        String port = mysql.getString("port");
+        String database = mysql.getString("database");
+        String username = mysql.getString("username");
+        String password = mysql.getString("password");
 
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database);
         hikariConfig.setUsername(username);
         hikariConfig.setPassword(password);
-        
+
         hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
         hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
         hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
@@ -78,27 +87,29 @@ public abstract class NotMySQL extends NotDatabase {
         hikariConfig.addDataSourceProperty("cacheServerConfiguration", "true");
         hikariConfig.addDataSourceProperty("elideSetAutoCommits", "true");
         hikariConfig.addDataSourceProperty("maintainTimeStats", "false");
-        
+
         hikariConfig.setMaximumPoolSize(20);
         hikariConfig.setMinimumIdle(5);
         hikariConfig.setIdleTimeout(30000);
         hikariConfig.setConnectionTimeout(10000);
-        
+
         source = new HikariDataSource(hikariConfig);
     }
 
     /**
      * @brief Creates a new table in the MySQL database if it doesn't exist
      * 
-     * This method generates and executes a SQL statement to create a table based on the provided
-     * NotTable specification. The method handles various column types, constraints, and attributes
-     * including:
-     * - Column types with appropriate length/precision/scale parameters
-     * - Primary key constraints (both at column level and table level)
-     * - Auto increment columns
-     * - NOT NULL constraints
-     * - UNIQUE constraints
-     * - DEFAULT values (both raw and quoted)
+     *        This method generates and executes a SQL statement to create a table
+     *        based on the provided
+     *        NotTable specification. The method handles various column types,
+     *        constraints, and attributes
+     *        including:
+     *        - Column types with appropriate length/precision/scale parameters
+     *        - Primary key constraints (both at column level and table level)
+     *        - Auto increment columns
+     *        - NOT NULL constraints
+     *        - UNIQUE constraints
+     *        - DEFAULT values (both raw and quoted)
      * 
      * @param table The NotTable object containing the table schema definition
      * @return true if the table was created successfully, false otherwise
@@ -113,22 +124,29 @@ public abstract class NotMySQL extends NotDatabase {
             NotColumn column = table.getColumns().get(i);
             NotColumnType type = column.getType();
             sql.append(column.getName()).append(" ").append(type.getSqlType());
-            
-            if (type == NotColumnType.VARCHAR || type == NotColumnType.CHAR || 
-                type == NotColumnType.BIT || type == NotColumnType.BINARY || 
-                type == NotColumnType.VARBINARY) {
+
+            if (type == NotColumnType.VARCHAR || type == NotColumnType.CHAR ||
+                    type == NotColumnType.BIT || type == NotColumnType.BINARY ||
+                    type == NotColumnType.VARBINARY) {
                 sql.append("(").append(column.getLength()).append(")");
             } else if (type == NotColumnType.DECIMAL) {
                 sql.append("(").append(column.getPrecision()).append(",").append(column.getScale()).append(")");
             }
-            
-            if (column.isPrimaryKey()) sql.append(" PRIMARY KEY");
-            if (column.isAutoIncrement()) sql.append(" AUTO_INCREMENT");
-            if (column.isNotNull()) sql.append(" NOT NULL");
-            if (column.isUnique()) sql.append(" UNIQUE");
-            if (column.getRawDefaultValue() != null) sql.append(" DEFAULT ").append(column.getRawDefaultValue());
-            if (column.getDefaultValue() != null) sql.append(" DEFAULT '").append(column.getDefaultValue()).append("'");
-            if (i < table.getColumns().size() - 1) sql.append(", ");
+
+            if (column.isPrimaryKey())
+                sql.append(" PRIMARY KEY");
+            if (column.isAutoIncrement())
+                sql.append(" AUTO_INCREMENT");
+            if (column.isNotNull())
+                sql.append(" NOT NULL");
+            if (column.isUnique())
+                sql.append(" UNIQUE");
+            if (column.getRawDefaultValue() != null)
+                sql.append(" DEFAULT ").append(column.getRawDefaultValue());
+            if (column.getDefaultValue() != null)
+                sql.append(" DEFAULT '").append(column.getDefaultValue()).append("'");
+            if (i < table.getColumns().size() - 1)
+                sql.append(", ");
         }
 
         List<String> primaryKeys = table.getPrimaryKeys();
@@ -137,11 +155,12 @@ public abstract class NotMySQL extends NotDatabase {
             for (int i = 0; i < primaryKeys.size(); i++) {
                 String primaryKey = primaryKeys.get(i);
                 sql.append(primaryKey);
-                if (i < primaryKeys.size() - 1) sql.append(", ");
+                if (i < primaryKeys.size() - 1)
+                    sql.append(", ");
             }
             sql.append(")");
         }
-        
+
         sql.append(");");
 
         return processResult(sql.toString());
@@ -150,12 +169,15 @@ public abstract class NotMySQL extends NotDatabase {
     /**
      * @brief Inserts a row into the specified table.
      *
-     * Constructs an SQL INSERT statement based on the table structure and the provided row data.
-     * Automatically skips auto-increment columns during SQL generation.
-     * The method logs the generated SQL and parameter values if debugging is enabled.
+     *        Constructs an SQL INSERT statement based on the table structure and
+     *        the provided row data.
+     *        Automatically skips auto-increment columns during SQL generation.
+     *        The method logs the generated SQL and parameter values if debugging is
+     *        enabled.
      *
      * @param table The NotTable object representing the table to insert into
-     * @param row A list of objects containing the values to be inserted in the same order as the table columns
+     * @param row   A list of objects containing the values to be inserted in the
+     *              same order as the table columns
      * @return true if the row was successfully inserted, false otherwise
      * @throws SQLException handled internally, prints stack trace and returns false
      */
@@ -166,13 +188,15 @@ public abstract class NotMySQL extends NotDatabase {
             NotColumn column = table.getColumns().get(i);
             if (!column.isAutoIncrement()) {
                 sql.append(column.getName());
-                if (i < table.getColumns().size() - 1) sql.append(", ");
+                if (i < table.getColumns().size() - 1)
+                    sql.append(", ");
             }
         }
         sql.append(") VALUES (");
         for (int i = 0; i < row.size(); i++) {
             sql.append("?");
-            if (i < row.size() - 1) sql.append(", ");
+            if (i < row.size() - 1)
+                sql.append(", ");
         }
         sql.append(")");
 
@@ -180,14 +204,14 @@ public abstract class NotMySQL extends NotDatabase {
         if (!row.isEmpty()) {
             NotLib.dbg().log(NotDebugger.C_DATABASE, "[MySQL insertRow] Params: " + row);
         }
-        
+
         try (Connection conn = getConnection();
-            PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
-            
+                PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+
             for (int i = 0; i < row.size(); i++) {
                 stmt.setObject(i + 1, row.get(i));
             }
-            
+
             return stmt.executeUpdate() > 0;
         } catch (SQLException e) {
             plugin.getLogger().severe("Error inserting row: " + e.getMessage());

--- a/src/main/java/com/notmarra/notlib/database/source/NotSQLite.java
+++ b/src/main/java/com/notmarra/notlib/database/source/NotSQLite.java
@@ -22,54 +22,61 @@ import org.bukkit.configuration.ConfigurationSection;
  * @class NotSQLite
  * @brief Abstract SQLite implementation of the NotDatabase class.
  *
- * NotSQLite provides SQLite database functionality using HikariCP connection pooling.
- * This class handles the specifics of connecting to an SQLite database file and
- * creating SQL statements compatible with SQLite syntax, such as table creation
- * and row insertion.
+ *        NotSQLite provides SQLite database functionality using HikariCP
+ *        connection pooling.
+ *        This class handles the specifics of connecting to an SQLite database
+ *        file and
+ *        creating SQL statements compatible with SQLite syntax, such as table
+ *        creation
+ *        and row insertion.
  *
  * @extends NotDatabase
  * 
  * @details
- * The class establishes a connection to an SQLite database specified in the plugin configuration.
- * It configures HikariCP connection pool with SQLite-appropriate settings and provides
- * methods for database operations like table creation and data insertion.
+ *          The class establishes a connection to an SQLite database specified
+ *          in the plugin configuration.
+ *          It configures HikariCP connection pool with SQLite-appropriate
+ *          settings and provides
+ *          methods for database operations like table creation and data
+ *          insertion.
  *
- * SQLite-specific features:
- * - Uses file-based database storage
- * - Implements AUTOINCREMENT instead of standard AUTO_INCREMENT
- * - Creates SQLite-compatible table schemas
+ *          SQLite-specific features:
+ *          - Uses file-based database storage
+ *          - Implements AUTOINCREMENT instead of standard AUTO_INCREMENT
+ *          - Creates SQLite-compatible table schemas
  *
- * @note When working with SQLite, be aware of its limitations compared to other RDBMS,
- * including limited concurrent access and transaction isolation.
+ * @note When working with SQLite, be aware of its limitations compared to other
+ *       RDBMS,
+ *       including limited concurrent access and transaction isolation.
  */
 public abstract class NotSQLite extends NotDatabase {
-    public static final String ID = "SQLite";
-
-    public NotSQLite(NotPlugin plugin, String defaultConfig) { super(plugin, defaultConfig); }
-
-    @Override
-    public String getId() { return ID; }
+    public NotSQLite(NotPlugin plugin, String defaultConfig) {
+        super(plugin, defaultConfig);
+    }
 
     /**
      * @brief Establishes a connection to the SQLite database using HikariCP.
      * 
-     * This method configures and initializes a connection to the SQLite database specified in the
-     * plugin's configuration. It uses HikariCP for connection pooling with optimized settings.
+     *        This method configures and initializes a connection to the SQLite
+     *        database specified in the
+     *        plugin's configuration. It uses HikariCP for connection pooling with
+     *        optimized settings.
      * 
-     * The method performs the following steps:
-     * 1. Retrieves the database configuration
-     * 2. Gets the database file path from configuration
-     * 3. Configures HikariCP with SQLite-specific settings
-     * 4. Sets connection pool properties (size, timeout, etc.)
-     * 5. Creates and initializes the HikariDataSource
+     *        The method performs the following steps:
+     *        1. Retrieves the database configuration
+     *        2. Gets the database file path from configuration
+     *        3. Configures HikariCP with SQLite-specific settings
+     *        4. Sets connection pool properties (size, timeout, etc.)
+     *        5. Creates and initializes the HikariDataSource
      * 
-     * @throws IllegalArgumentException if the database file path is not specified in the configuration
+     * @throws IllegalArgumentException if the database file path is not specified
+     *                                  in the configuration
      */
     @Override
     public void connect() {
         ConfigurationSection configSection = getDatabaseConfig();
-
         String databasePath = configSection.getString("file");
+
         if (databasePath == null) {
             throw new IllegalArgumentException("Database file path is not specified in the configuration.");
         }
@@ -80,12 +87,12 @@ public abstract class NotSQLite extends NotDatabase {
         File databaseFile = new File(plugin.getDataFolder(), databasePath);
         hikariConfig.setJdbcUrl("jdbc:sqlite:" + databaseFile.getAbsolutePath());
         // hikariConfig.setDataSourceClassName("org.sqlite.SQLiteDataSource");
-        hikariConfig.setPoolName(ID);
+        hikariConfig.setPoolName(getId());
         hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
         hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
         hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
-        
-        hikariConfig.setMaximumPoolSize(10); 
+
+        hikariConfig.setMaximumPoolSize(10);
         hikariConfig.setMinimumIdle(2);
         hikariConfig.setIdleTimeout(30000);
         hikariConfig.setConnectionTimeout(10000);
@@ -96,19 +103,26 @@ public abstract class NotSQLite extends NotDatabase {
     /**
      * @brief Creates a new table in the SQLite database if it doesn't exist
      * 
-     * This method constructs an SQL CREATE TABLE statement based on the provided NotTable
-     * object and executes it against the SQLite database. The statement includes column 
-     * definitions with appropriate data types, constraints (PRIMARY KEY, NOT NULL, UNIQUE),
-     * and support for autoincrement. For certain data types, it also handles length and
-     * precision specifications.
+     *        This method constructs an SQL CREATE TABLE statement based on the
+     *        provided NotTable
+     *        object and executes it against the SQLite database. The statement
+     *        includes column
+     *        definitions with appropriate data types, constraints (PRIMARY KEY, NOT
+     *        NULL, UNIQUE),
+     *        and support for autoincrement. For certain data types, it also handles
+     *        length and
+     *        precision specifications.
      * 
-     * @param table A NotTable object containing the table definition including name, columns,
+     * @param table A NotTable object containing the table definition including
+     *              name, columns,
      *              and primary key information
      * @return boolean True if the operation was successful, false otherwise
      * 
-     * @note For VARCHAR, CHAR, BIT, BINARY, and VARBINARY types, length specification is applied
+     * @note For VARCHAR, CHAR, BIT, BINARY, and VARBINARY types, length
+     *       specification is applied
      * @note For DECIMAL type, both precision and scale are specified
-     * @note Composite primary keys are supported through the table's primaryKeys list
+     * @note Composite primary keys are supported through the table's primaryKeys
+     *       list
      */
     @Override
     public boolean createTable(NotTable table) {
@@ -117,20 +131,25 @@ public abstract class NotSQLite extends NotDatabase {
             NotColumn column = table.getColumns().get(i);
             NotColumnType type = column.getType();
             sql.append(column.getName()).append(" ").append(type.getSqlType());
-            
-            if (type == NotColumnType.VARCHAR || type == NotColumnType.CHAR || 
-                type == NotColumnType.BIT || type == NotColumnType.BINARY || 
-                type == NotColumnType.VARBINARY) {
+
+            if (type == NotColumnType.VARCHAR || type == NotColumnType.CHAR ||
+                    type == NotColumnType.BIT || type == NotColumnType.BINARY ||
+                    type == NotColumnType.VARBINARY) {
                 sql.append("(").append(column.getLength()).append(")");
             } else if (type == NotColumnType.DECIMAL) {
                 sql.append("(").append(column.getPrecision()).append(",").append(column.getScale()).append(")");
             }
 
-            if (column.isPrimaryKey()) sql.append(" PRIMARY KEY");
-            if (column.isAutoIncrement()) sql.append(" AUTOINCREMENT");
-            if (column.isNotNull()) sql.append(" NOT NULL");
-            if (column.isUnique()) sql.append(" UNIQUE");
-            if (i < table.getColumns().size() - 1) sql.append(", ");
+            if (column.isPrimaryKey())
+                sql.append(" PRIMARY KEY");
+            if (column.isAutoIncrement())
+                sql.append(" AUTOINCREMENT");
+            if (column.isNotNull())
+                sql.append(" NOT NULL");
+            if (column.isUnique())
+                sql.append(" UNIQUE");
+            if (i < table.getColumns().size() - 1)
+                sql.append(", ");
         }
 
         List<String> primaryKeys = table.getPrimaryKeys();
@@ -139,7 +158,8 @@ public abstract class NotSQLite extends NotDatabase {
             for (int i = 0; i < primaryKeys.size(); i++) {
                 String primaryKey = primaryKeys.get(i);
                 sql.append(primaryKey);
-                if (i < primaryKeys.size() - 1) sql.append(", ");
+                if (i < primaryKeys.size() - 1)
+                    sql.append(", ");
             }
             sql.append(")");
         }
@@ -152,13 +172,17 @@ public abstract class NotSQLite extends NotDatabase {
     /**
      * @brief Inserts a new row into the specified database table.
      * 
-     * This method generates and executes an SQL INSERT statement for the given table and row data.
-     * It automatically handles auto-increment columns by excluding them from the INSERT statement.
-     * The method logs both the generated SQL query and its parameters for debugging purposes.
+     *        This method generates and executes an SQL INSERT statement for the
+     *        given table and row data.
+     *        It automatically handles auto-increment columns by excluding them from
+     *        the INSERT statement.
+     *        The method logs both the generated SQL query and its parameters for
+     *        debugging purposes.
      *
      * @param table The database table where the row should be inserted
-     * @param row A list containing the values to be inserted, in the same order as the table columns
-     *            (excluding auto-increment columns)
+     * @param row   A list containing the values to be inserted, in the same order
+     *              as the table columns
+     *              (excluding auto-increment columns)
      * @return true if the row was successfully inserted, false otherwise
      * @throws SQLException internally handled, logged to the plugin's logger
      */
@@ -169,13 +193,15 @@ public abstract class NotSQLite extends NotDatabase {
             NotColumn column = table.getColumns().get(i);
             if (!column.isAutoIncrement()) {
                 sql.append(column.getName());
-                if (i < table.getColumns().size() - 1) sql.append(", ");
+                if (i < table.getColumns().size() - 1)
+                    sql.append(", ");
             }
         }
         sql.append(") VALUES (");
         for (int i = 0; i < row.size(); i++) {
             sql.append("?");
-            if (i < row.size() - 1) sql.append(", ");
+            if (i < row.size() - 1)
+                sql.append(", ");
         }
         sql.append(")");
 
@@ -183,14 +209,14 @@ public abstract class NotSQLite extends NotDatabase {
         if (!row.isEmpty()) {
             NotLib.dbg().log(NotDebugger.C_DATABASE, "[MySQL insertRow] Params: " + row);
         }
-        
+
         try (Connection conn = getConnection();
-            PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
-            
+                PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+
             for (int i = 0; i < row.size(); i++) {
                 stmt.setObject(i + 1, row.get(i));
             }
-            
+
             return stmt.executeUpdate() > 0;
         } catch (SQLException e) {
             plugin.getLogger().severe("Error inserting row: " + e.getMessage());


### PR DESCRIPTION
Refactored NotDatabase and its subclasses to use a unified 'data' section in config.yml, removing the need for hardcoded database IDs. Updated NotMySQL and NotSQLite to read configuration from the new structure. Enhanced and expanded the documentation in examples/database.md to clarify setup and usage. Bumped project version to 0.0.2.