### PR TITLE
Add default config handling in NotPlugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.notmarra</groupId>
     <artifactId>NotLib</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <packaging>jar</packaging>
 
     <name>NotLib</name>

--- a/src/main/java/com/notmarra/notlib/extensions/NotPlugin.java
+++ b/src/main/java/com/notmarra/notlib/extensions/NotPlugin.java
@@ -129,10 +129,31 @@ public abstract class NotPlugin extends JavaPlugin {
             return;
         if (CONFIGS.containsKey(configPath))
             return;
+
         File configFile = new File(getDataFolder(), configPath);
         if (!configFile.exists())
             return;
-        CONFIGS.put(configPath, YamlConfiguration.loadConfiguration(configFile));
+
+        FileConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+
+        java.io.InputStream defaultStream = getResource(configPath);
+
+        if (defaultStream != null) {
+            YamlConfiguration defaultConfig = YamlConfiguration
+                    .loadConfiguration(new java.io.InputStreamReader(defaultStream));
+
+            config.setDefaults(defaultConfig);
+
+            config.options().copyDefaults(true);
+
+            try {
+                config.save(configFile);
+            } catch (IOException e) {
+                getComponentLogger().error("Failed to update configuration file: " + configPath, e);
+            }
+        }
+
+        CONFIGS.put(configPath, config);
     }
 
     public File getFile(String child) {


### PR DESCRIPTION
Enhanced the NotPlugin class to load and apply default configuration values from resources when loading config files. The config file is now updated with defaults if available, improving configuration management. Also bumped project version to 0.0.6 in pom.xml.