### PR TITLE
FileManager & integration

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,9 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="REPORT_INACCESSIBLE" value="false" />
+    </inspection_tool>
     <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false" checkParameterExcludingHierarchy="false">
       <option name="LOCAL_VARIABLE" value="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.notmarra</groupId>
     <artifactId>notlib</artifactId>
-    <version>1.0-DEV</version>
+    <version>0.1.0-DEV</version>
     <packaging>jar</packaging>
 
     <name>notlib</name>

--- a/src/main/java/dev/notmarra/notlib/extensions/Configurable.java
+++ b/src/main/java/dev/notmarra/notlib/extensions/Configurable.java
@@ -1,9 +1,21 @@
 package dev.notmarra.notlib.extensions;
 
+import dev.notmarra.notlib.file.ConfigFileManager;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.List;
 
+/**
+ * Base class for any plugin component that reads from one or more config files.
+ *
+ * <p>Subclasses declare their config paths via {@link #getConfigPaths()} and receive
+ * {@link #onConfigReload} whenever those files are reloaded – either programmatically
+ * or via a server command.
+ *
+ * <p>The {@link ConfigFileManager} integration happens transparently through
+ * {@link NotPlugin#registerConfigurable}: the plugin registers the file with the CFM,
+ * the CFM handles disk I/O and auto-update, and the configurable receives callbacks.
+ */
 public abstract class Configurable {
     public final NotPlugin plugin;
 
@@ -11,35 +23,95 @@ public abstract class Configurable {
 
     public NotPlugin getPlugin() { return plugin; }
 
+    // -----------------------------------------------------------------------
+    // Config access – thin wrappers over NotPlugin / CFM
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the {@link FileConfiguration} for the given path.
+     * Delegates to {@link NotPlugin#getSubConfig(String)} which reads from the CFM cache.
+     */
     public FileConfiguration getConfig(String path) { return plugin.getSubConfig(path); }
 
+    /**
+     * Returns the {@link FileConfiguration} for the first path in {@link #getConfigPaths()}.
+     */
     public FileConfiguration getFirstConfig() { return plugin.getSubConfig(getConfigPaths().getFirst()); }
 
-    // e.g: return getPluginConfig().getBoolean("modules.something");
-    public boolean isEnabled() { return true; }
-
+    /**
+     * Returns the plugin's main {@code config.yml}.
+     *
+     * <p>Example usage in {@link #isEnabled()}:
+     * <pre>{@code
+     * return getPluginConfig().getBoolean("modules.something");
+     * }</pre>
+     */
     public FileConfiguration getPluginConfig() { return plugin.getConfig(); }
 
+    // -----------------------------------------------------------------------
+    // Lifecycle hooks
+    // -----------------------------------------------------------------------
+
+    /**
+     * The config paths this component reads from.
+     * Override to declare dependencies on additional files.
+     *
+     * <p>Default: the plugin's main {@code config.yml}.
+     */
     public List<String> getConfigPaths() { return List.of(plugin.CONFIG_YML); }
 
+    /**
+     * Whether this component should be considered active.
+     * Called during registration; return {@code false} to skip event/command registration
+     * in {@link NotListener} subclasses.
+     *
+     * <p>Default: always enabled.
+     */
+    public boolean isEnabled() { return true; }
+
+    /**
+     * Called after one or more of this component's config files have been reloaded.
+     *
+     * @param reloadedConfigs the subset of {@link #getConfigPaths()} that were reloaded
+     */
     public void onConfigReload(List<String> reloadedConfigs) {}
 
-    public Configurable reload() { onConfigReload(getConfigPaths()); return this; }
+    // -----------------------------------------------------------------------
+    // Reload helpers
+    // -----------------------------------------------------------------------
 
-    public Configurable reloadWithFiles() {
-        getConfigPaths().forEach(path -> plugin.reloadConfig(path));
+    /**
+     * Notifies this component that its configs have changed without re-reading files from disk.
+     * Use when you already reloaded the files elsewhere and just need to propagate the change.
+     */
+    public Configurable reload() {
         onConfigReload(getConfigPaths());
         return this;
     }
 
-    //public ComponentLogger getLogger() { return plugin.getComponentLogger(); }
+    /**
+     * Reloads all config files for this component from disk via the CFM, then calls
+     * {@link #onConfigReload}.
+     *
+     * <p>This replaces the old manual approach of calling {@code plugin.reloadConfig(path)}
+     * per-path; the CFM now handles disk I/O, auto-update and caching.
+     */
+    public Configurable reloadWithFiles() {
+        getConfigPaths().forEach(path -> plugin.reloadConfig(path));
+        // onConfigReload is triggered by NotPlugin.reloadConfig via the CONFIGURABLES index
+        return this;
+    }
 
-    /* TODO
-    public NotTranslationManager tm() { return plugin.tm(); }
-    public String tm(String key) { return plugin.tm(key); }
-    public List<String> tmList(String key) { return plugin.tmList(key); }
-    */
+    // -----------------------------------------------------------------------
+    // Registration
+    // -----------------------------------------------------------------------
 
+    /**
+     * Registers this configurable with the plugin, which in turn registers its config
+     * paths with the {@link ConfigFileManager}.
+     *
+     * <p>Equivalent to calling {@code plugin.registerConfigurable(this)}.
+     */
     public Configurable registerConfigurable() {
         plugin.registerConfigurable(this);
         return this;

--- a/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
+++ b/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
@@ -1,5 +1,8 @@
 package dev.notmarra.notlib.extensions;
 
+import dev.notmarra.notlib.file.ConfigFileManager;
+import dev.notmarra.notlib.file.ConfigOptions;
+import dev.notmarra.notlib.file.ManagedConfig;
 import dev.notmarra.notlib.chat.Colors;
 import dev.notmarra.notlib.chat.Text;
 import dev.notmarra.notlib.scheduler.Scheduler;
@@ -15,193 +18,241 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 public abstract class NotPlugin extends JavaPlugin {
-    private final Map<String, Runnable> ON_PLUGIN_ENABLED_CALLBACKS = new HashMap<>();
-    // <path, config>
-    private final Map<String, FileConfiguration> CONFIGS = new HashMap<>();
-    // <id, listener>
-    private final Map<String, NotListener> LISTENERS = new HashMap<>();
-    // <id, cmdGroup>
-    private final Map<String, CommandGroup> CMDGROUPS = new HashMap<>();
-    // <path, [configurable]>
+    private final Map<String, Runnable>         ON_PLUGIN_ENABLED_CALLBACKS = new HashMap<>();
+    private final Map<String, NotListener>      LISTENERS   = new HashMap<>();
+    private final Map<String, CommandGroup>     CMDGROUPS   = new HashMap<>();
+    // <configPath, [configurable]>  – kept for onConfigReload callbacks
     private final Map<String, List<Configurable>> CONFIGURABLES = new HashMap<>();
 
+    // -----------------------------------------------------------------------
+    // ConfigFileManager – single source of truth for all config files
+    // -----------------------------------------------------------------------
+
+    private ConfigFileManager cfm;
+
+    /**
+     * Returns the plugin's {@link ConfigFileManager}.
+     * Available after {@link #onEnable()} initialises it; do not call from a static context.
+     */
+    public ConfigFileManager getCfm() { return cfm; }
+
+    // -----------------------------------------------------------------------
+    // Legacy shims – keep existing API working unchanged
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the relative paths of all config files currently managed by the CFM.
+     * Drop-in replacement for the old {@code CONFIGS.keySet()} approach.
+     */
     public List<String> getConfigFilePaths() {
-        return CONFIGS.keySet().stream().toList();
-    }
-    /* TODO
-    private TranslationManager translationManager;
-
-    public TranslationManager tm() {
-        return translationManager;
+        return cfm.getAll().keySet().stream().toList();
     }
 
-    public String tm(String key) {
-        return tm().get(key);
-    }
+    // -----------------------------------------------------------------------
+    // Scheduler & constants
+    // -----------------------------------------------------------------------
 
-    public List<String> tmList(String key) {
-        return tm().getList(key);
-    }
-
-    private DatabaseManager databaseManager;
-
-    public DatabaseManager db() {
-        return databaseManager;
-    }
-
-    public Database db(String dbId) {
-        return databaseManager.getDatabase(dbId);
-    }
-
-    */
     private Scheduler scheduler;
 
-    public Scheduler scheduler() {
-        return scheduler;
-    }
+    public Scheduler scheduler() { return scheduler; }
 
     public final String CONFIG_YML = "config.yml";
+
+    // -----------------------------------------------------------------------
+    // Listener / CommandGroup registration (unchanged)
+    // -----------------------------------------------------------------------
 
     public void addPluginEnabledCallback(String pluginId, Runnable callback) {
         ON_PLUGIN_ENABLED_CALLBACKS.put(pluginId, callback);
     }
 
-    // addListener("listener_id", new Listener(this));
     public void addListener(NotListener notListener) {
         LISTENERS.put(notListener.getId(), notListener);
     }
 
-    public NotListener getListener(String id) {
-        return LISTENERS.get(id);
-    }
+    public NotListener getListener(String id) { return LISTENERS.get(id); }
 
-    // addCommandManager("cmdgroup_id", new CommandManager(this));
     public void addCommandGroup(CommandGroup cmdGroup) {
         CMDGROUPS.put(cmdGroup.getId(), cmdGroup);
     }
 
-    public CommandGroup getCommandGroup(String id) {
-        return CMDGROUPS.get(id);
-    }
+    public CommandGroup getCommandGroup(String id) { return CMDGROUPS.get(id); }
 
+    // -----------------------------------------------------------------------
+    // Configurable registration
+    // -----------------------------------------------------------------------
+
+    /**
+     * Registers a {@link Configurable} for a specific config path.
+     *
+     * <ul>
+     *   <li>If the path is not yet tracked by the CFM it is registered and loaded.</li>
+     *   <li>The configurable is added to the callback list for that path so it receives
+     *       {@link Configurable#onConfigReload} on every reload.</li>
+     * </ul>
+     */
     public void registerConfigurable(Configurable configurable, String configPath) {
-        CONFIGURABLES.computeIfAbsent(configPath, k -> new ArrayList<>());
-        if (!CONFIGURABLES.get(configPath).contains(configurable)) {
-            CONFIGURABLES.get(configPath).add(configurable);
-        }
+        // Register in the callback index
+        CONFIGURABLES.computeIfAbsent(configPath, k -> new ArrayList<>())
+                .add(configurable);
 
-        if (getResource(configPath) != null) {
-            saveDefaultConfig(configPath);
+        // Ensure CFM knows about this file (idempotent)
+        if (!cfm.isRegistered(configPath)) {
+            cfm.register(configPath);
+            cfm.load(configPath);
         }
-        loadConfigFile(configPath);
     }
 
+    /**
+     * Registers a {@link Configurable} for all paths returned by
+     * {@link Configurable#getConfigPaths()}, then triggers an initial reload.
+     */
     public void registerConfigurable(Configurable configurable) {
-        List<String> configPaths = configurable.getConfigPaths();
-        if (configPaths.isEmpty())
-            return;
-        configPaths.forEach(path -> {
-            registerConfigurable(configurable, path);
-            loadConfigFile(path);
-        });
+        List<String> paths = configurable.getConfigPaths();
+        if (paths.isEmpty()) return;
+        paths.forEach(path -> registerConfigurable(configurable, path));
         configurable.reload();
     }
 
+    // -----------------------------------------------------------------------
+    // Config access – delegates to CFM
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the {@link FileConfiguration} for the given relative path.
+     * Forwards to the underlying {@link ManagedConfig} in the CFM.
+     *
+     * <p>Returns an empty {@link YamlConfiguration} if the file is not registered,
+     * preserving the old null-safe behaviour callers may rely on.
+     */
+    public FileConfiguration getSubConfig(String file) {
+        if (!cfm.isRegistered(file)) return new YamlConfiguration();
+        return cfm.get(file).yaml();
+    }
+
+    /**
+     * Reloads a config file from disk, updates the CFM cache and notifies all
+     * registered {@link Configurable} instances for that path.
+     *
+     * <p>Drop-in replacement for the old {@code reloadConfig(String)} method.
+     */
+    public FileConfiguration reloadConfig(String file) {
+        if (!cfm.isRegistered(file)) return new YamlConfiguration();
+
+        cfm.reload(file);   // re-reads disk + runs auto-update
+
+        // Notify all configurables registered for this path
+        List<Configurable> subscribers = CONFIGURABLES.getOrDefault(file, List.of());
+        subscribers.forEach(c -> c.onConfigReload(List.of(file)));
+
+        return cfm.get(file).yaml();
+    }
+
+    // -----------------------------------------------------------------------
+    // Directory watching – new feature, integrates with CFM
+    // -----------------------------------------------------------------------
+
+    /**
+     * Watches a directory for user-created YAML files (e.g. language packs, arena configs).
+     *
+     * <p>Delegates to {@link ConfigFileManager#watchDirectory}. Call this from
+     * {@link #initPlugin()} before {@code loadAll()} / {@code onPluginEnable()}.
+     *
+     * <pre>{@code
+     * // In initPlugin():
+     * watchUserDirectory("languages", ConfigOptions.builder()
+     *         .autoUpdate(false)
+     *         .seedFile("languages/en_US.yml")
+     *         .build());
+     * }</pre>
+     *
+     * @param dirPath relative path inside the plugin data folder
+     * @param options options applied to every file found in the directory
+     */
+    public void watchUserDirectory(String dirPath, ConfigOptions options) {
+        cfm.watchDirectory(dirPath, options);
+    }
+
+    /** @see #watchUserDirectory(String, ConfigOptions) */
+    public void watchUserDirectory(String dirPath) {
+        cfm.watchDirectory(dirPath);
+    }
+
+    // -----------------------------------------------------------------------
+    // Legacy config helpers (saveDefaultConfig / loadConfigFile kept for
+    // back-compat; internally they now go through CFM)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Copies the resource to disk if it does not yet exist, then ensures the CFM
+     * has it registered. Equivalent to the old {@code saveDefaultConfig(String)}.
+     */
     public void saveDefaultConfig(String forConfig) {
-        if (forConfig == null)
-            return;
-        if (CONFIGS.containsKey(forConfig))
-            return;
+        if (forConfig == null) return;
+
         File configFile = new File(getDataFolder(), forConfig);
-        if (configFile.exists())
-            return;
-        if (getResource(forConfig) == null)
-            return;
-        configFile.getParentFile().mkdirs();
-        saveResource(forConfig, false);
+        if (!configFile.exists() && getResource(forConfig) != null) {
+            configFile.getParentFile().mkdirs();
+            saveResource(forConfig, false);
+        }
+
+        // Register with CFM (noop if already registered)
+        if (!cfm.isRegistered(forConfig)) {
+            cfm.register(forConfig);
+        }
     }
 
+    /**
+     * Loads a config file through the CFM.
+     * No-op if the file does not exist on disk (preserves old behaviour).
+     *
+     * @deprecated Use {@link ConfigFileManager#load(String)} directly via {@link #getCfm()}.
+     */
+    @Deprecated
     private void loadConfigFile(String configPath) {
-        if (configPath == null || CONFIGS.containsKey(configPath))
-            return;
+        if (configPath == null) return;
+        File f = new File(getDataFolder(), configPath);
+        if (!f.exists()) return;
 
-        File configFile = new File(getDataFolder(), configPath);
-        if (!configFile.exists())
-            return;
-
-        FileConfiguration config = YamlConfiguration.loadConfiguration(configFile);
-
-        java.io.InputStream defaultStream = getResource(configPath);
-
-        /* TODO
-        if (defaultStream == null && translationManager != null) {
-
-            String langFolder = "lang/";
-            if (configPath.startsWith(langFolder)) {
-                defaultStream = getResource(langFolder + "en.yml");
-            }
+        if (!cfm.isRegistered(configPath)) {
+            cfm.register(configPath);
         }
-        */
-
-        if (defaultStream != null) {
-            YamlConfiguration defaultConfig = YamlConfiguration.loadConfiguration(
-                    new java.io.InputStreamReader(defaultStream));
-
-            config.setDefaults(defaultConfig);
-            config.options().copyDefaults(true);
-
-            try {
-                config.save(configFile);
-            } catch (IOException e) {
-                getComponentLogger().error("Failed to update configuration file: " + configPath, e);
-            }
-        }
-
-        CONFIGS.put(configPath, config);
+        cfm.load(configPath);
     }
 
-    public File getFile(String child) {
-        return new File(getDataFolder(), child);
-    }
-
-    public String getAbsPath(String child) {
-        return (new File(getDataFolder(), child)).getAbsolutePath();
-    }
+    // -----------------------------------------------------------------------
+    // Plugin lifecycle
+    // -----------------------------------------------------------------------
 
     public abstract void initPlugin();
-
     public abstract void onPluginEnable();
-
     public abstract void onPluginDisable();
-
-    /* TODO
-    public ComponentLogger log() {
-        return getComponentLogger();
-    }
-    */
 
     @Override
     public void onEnable() {
         try {
-            //MinecraftStuff.getInstance().initialize();
-
-            //this.translationManager = new TranslationManager(this);
-            //this.databaseManager = new DatabaseManager(this);
             this.scheduler = new Scheduler(this);
 
+            // Initialise the CFM early so initPlugin() can call register/watchDirectory
+            this.cfm = new ConfigFileManager(this);
+
+            // Ensure the main config is always available
             saveDefaultConfig(CONFIG_YML);
-            loadConfigFile(CONFIG_YML);
-            //tm().discoverAndRegisterLocalLangs();
+            cfm.load(CONFIG_YML);
+
             initPlugin();
 
-            for (String pluginId : ON_PLUGIN_ENABLED_CALLBACKS.keySet()) {
-                if (Bukkit.getPluginManager().isPluginEnabled(pluginId)) {
-                    ON_PLUGIN_ENABLED_CALLBACKS.get(pluginId).run();
-                }
-            }
+            // Load everything the plugin registered during initPlugin()
+            cfm.loadAll();
 
-            LISTENERS.values().forEach(l -> l.register());
-            CMDGROUPS.values().forEach(c -> c.register());
+            // Fire plugin-enabled callbacks
+            ON_PLUGIN_ENABLED_CALLBACKS.forEach((pluginId, cb) -> {
+                if (Bukkit.getPluginManager().isPluginEnabled(pluginId)) cb.run();
+            });
+
+            LISTENERS.values().forEach(NotListener::register);
+            CMDGROUPS.values().forEach(CommandGroup::register);
+
             onPluginEnable();
         } catch (Exception e) {
             getComponentLogger().error(
@@ -209,7 +260,8 @@ public abstract class NotPlugin extends JavaPlugin {
                             .append("[CRITICAL ERROR] Disabling plugin", Colors.RED.get())
                             .nl()
                             .appendListString(
-                                    List.of(e.getStackTrace()).stream().map(x -> "    " + x.toString() + '\n').toList(),
+                                    List.of(e.getStackTrace()).stream()
+                                            .map(x -> "    " + x + '\n').toList(),
                                     Colors.ORANGE.get())
                             .build());
             getServer().getPluginManager().disablePlugin(this);
@@ -219,51 +271,66 @@ public abstract class NotPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         onPluginDisable();
-        //db().close();
     }
 
-    public FileConfiguration getSubConfig(String file) {
-        return CONFIGS.get(file);
-    }
+    // -----------------------------------------------------------------------
+    // Utilities
+    // -----------------------------------------------------------------------
 
-    public FileConfiguration reloadConfig(String file) {
-        File configFile = new File(getDataFolder(), file);
-        if (!configFile.exists())
-            return new YamlConfiguration();
-        CONFIGS.put(file, YamlConfiguration.loadConfiguration(configFile));
-        if (CONFIGURABLES.containsKey(file)) {
-            CONFIGURABLES.get(file).forEach(c -> c.onConfigReload(List.of(file)));
-        }
-        return CONFIGS.get(file);
-    }
+    public File getFile(String child)        { return new File(getDataFolder(), child); }
+    public String getAbsPath(String child)   { return new File(getDataFolder(), child).getAbsolutePath(); }
 
+    /**
+     * Lists all resources inside the given folder path in the plugin jar.
+     * Unchanged from the original implementation.
+     */
     public List<String> listResources(String folderPath) {
         List<String> resources = new ArrayList<>();
-
         try {
-            // Get the JAR file of your plugin
-            JarFile jarFile = new JarFile(this.getClass().getProtectionDomain()
-                    .getCodeSource().getLocation().getPath());
-
-            // Get all entries in the JAR
+            JarFile jarFile = new JarFile(
+                    this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
             Enumeration<JarEntry> entries = jarFile.entries();
-
-            // Loop through all entries
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 String name = entry.getName();
-
-                // Check if this entry is in the specified folder and is not a directory
-                if (name.startsWith(folderPath) && !name.endsWith("/")) {
-                    resources.add(name);
-                }
+                if (name.startsWith(folderPath) && !name.endsWith("/")) resources.add(name);
             }
-
             jarFile.close();
         } catch (IOException e) {
             e.printStackTrace();
         }
-
         return resources;
+    }
+
+    /**
+     * Convenience method: watches a directory whose contents are discovered via
+     * {@link #listResources(String)} and seeds it from jar resources on first run.
+     *
+     * <p>Useful for bundling multiple default files (e.g. all built-in language files)
+     * while still allowing users to add their own:
+     *
+     * <pre>{@code
+     * // Copies languages/en_US.yml and languages/cs_CZ.yml from the jar,
+     * // then also loads any extra *.yml files users drop into the folder.
+     * watchResourceDirectory("languages");
+     * }</pre>
+     *
+     * @param folderPath folder path as used in the jar (e.g. {@code "languages"})
+     */
+    public void watchResourceDirectory(String folderPath) {
+        // Copy every bundled file in the folder to disk on first run
+        listResources(folderPath + "/").forEach(resourcePath -> {
+            File dest = new File(getDataFolder(), resourcePath);
+            if (!dest.exists() && getResource(resourcePath) != null) {
+                dest.getParentFile().mkdirs();
+                saveResource(resourcePath, false);
+            }
+        });
+
+        // Then watch the directory so user-added files are also picked up
+        cfm.watchDirectory(folderPath, ConfigOptions.builder()
+                .autoUpdate(false)
+                .copyFromResources(false)
+                .build());
     }
 }

--- a/src/main/java/dev/notmarra/notlib/file/ConfigFileManager.java
+++ b/src/main/java/dev/notmarra/notlib/file/ConfigFileManager.java
@@ -1,0 +1,350 @@
+package dev.notmarra.notlib.file;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.*;
+import java.util.logging.Level;
+
+/**
+ * Central manager for configuration files in PaperMC plugins.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>YAML support with comment preservation</li>
+ *   <li>Auto-update: missing keys are added from the resource template while user values are kept</li>
+ *   <li>Multi-file management with a fluent registration API</li>
+ *   <li>Reload via API or a command handler</li>
+ *   <li>User-defined file directories: scan and load YAML files created by users at runtime</li>
+ * </ul>
+ *
+ * <h3>Basic usage:</h3>
+ * <pre>{@code
+ * ConfigFileManager cfm = new ConfigFileManager(plugin);
+ * cfm.register("config.yml")
+ *    .register("messages.yml")
+ *    .loadAll();
+ *
+ * String prefix = cfm.get("config.yml").getString("prefix", "[Plugin]");
+ * cfm.reload("config.yml");
+ * cfm.reloadAll();
+ * }</pre>
+ *
+ * <h3>User directories (e.g. custom language files):</h3>
+ * <pre>{@code
+ * cfm.watchDirectory("languages",
+ *     ConfigOptions.builder().autoUpdate(false).build())
+ *    .loadAll();
+ *
+ * // After a user drops "languages/de_DE.yml" on the server:
+ * cfm.reloadDirectory("languages");
+ * Collection<ManagedConfig> langs = cfm.getDirectory("languages");
+ * }</pre>
+ */
+public class ConfigFileManager {
+
+    private final JavaPlugin plugin;
+
+    /** Explicitly registered files, keyed by their relative path (e.g. "config.yml"). */
+    private final Map<String, ManagedConfig> configs = new LinkedHashMap<>();
+
+    /** Watched user directories, keyed by the directory path relative to the plugin data folder. */
+    private final Map<String, UserDirectory> directories = new LinkedHashMap<>();
+
+    public ConfigFileManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration – explicit files
+    // -----------------------------------------------------------------------
+
+    /**
+     * Registers a file with default options.
+     * If the file exists as a plugin resource it is used as the auto-update template.
+     *
+     * @param fileName file path relative to the plugin data folder (e.g. {@code "config.yml"},
+     *                 {@code "data/rewards.yml"})
+     * @return {@code this} for chaining
+     */
+    public ConfigFileManager register(String fileName) {
+        return register(fileName, ConfigOptions.defaults());
+    }
+
+    /**
+     * Registers a file with custom options.
+     *
+     * @param fileName file path relative to the plugin data folder
+     * @param options  per-file configuration options
+     * @return {@code this} for chaining
+     */
+    public ConfigFileManager register(String fileName, ConfigOptions options) {
+        if (configs.containsKey(fileName)) {
+            plugin.getLogger().warning("[ConfigFileManager] File '" + fileName + "' is already registered.");
+            return this;
+        }
+
+        ConfigFormat format  = ConfigFormat.detect(fileName);
+        File         file    = new File(plugin.getDataFolder(), fileName);
+        configs.put(fileName, new ManagedConfig(plugin, fileName, file, format, options));
+        return this;
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration – user directories
+    // -----------------------------------------------------------------------
+
+    /**
+     * Registers a directory whose YAML files are created and maintained by users at runtime
+     * (e.g. custom language files, per-arena configurations, reward packs).
+     *
+     * <p>On {@link #loadAll()} or {@link #reloadDirectory(String)} the manager scans the
+     * directory for {@code *.yml} / {@code *.yaml} files and loads every one it finds.
+     * Files added to the directory after the initial load are picked up on the next reload.
+     *
+     * <p>The directory is created automatically if it does not exist.
+     * An optional seed file from plugin resources can be copied there on first run to give
+     * users an example to copy and customise (see {@link ConfigOptions.Builder#seedFile}).
+     *
+     * @param dirPath relative path of the directory inside the plugin data folder
+     *                (e.g. {@code "languages"}, {@code "arenas"})
+     * @param options options applied to every file found inside the directory
+     * @return {@code this} for chaining
+     */
+    public ConfigFileManager watchDirectory(String dirPath, ConfigOptions options) {
+        if (directories.containsKey(dirPath)) {
+            plugin.getLogger().warning("[ConfigFileManager] Directory '" + dirPath + "' is already watched.");
+            return this;
+        }
+        File dir = new File(plugin.getDataFolder(), dirPath);
+        directories.put(dirPath, new UserDirectory(plugin, dirPath, dir, options));
+        return this;
+    }
+
+    /**
+     * Registers a directory with default options.
+     *
+     * @param dirPath relative path of the directory inside the plugin data folder
+     * @return {@code this} for chaining
+     * @see #watchDirectory(String, ConfigOptions)
+     */
+    public ConfigFileManager watchDirectory(String dirPath) {
+        return watchDirectory(dirPath, ConfigOptions.builder().autoUpdate(false).build());
+    }
+
+    // -----------------------------------------------------------------------
+    // Loading
+    // -----------------------------------------------------------------------
+
+    /**
+     * Loads (or creates) all registered files and scans all watched directories.
+     */
+    public void loadAll() {
+        for (ManagedConfig cfg : configs.values())    load(cfg);
+        for (UserDirectory  dir : directories.values()) loadDirectory(dir);
+    }
+
+    /**
+     * Loads a single registered file.
+     *
+     * @param fileName registered file name
+     * @throws IllegalArgumentException if the file is not registered
+     */
+    public void load(String fileName) {
+        load(getOrThrow(fileName));
+    }
+
+    private void load(ManagedConfig cfg) {
+        try {
+            cfg.load();
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[ConfigFileManager] Failed to load '" + cfg.getFileName() + "'", e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Reload
+    // -----------------------------------------------------------------------
+
+    /**
+     * Reloads all registered files and re-scans all watched directories from disk.
+     */
+    public void reloadAll() {
+        for (ManagedConfig cfg : configs.values())    reload(cfg);
+        for (UserDirectory  dir : directories.values()) reloadDirectory(dir.getDirPath());
+        plugin.getLogger().info("[ConfigFileManager] All configurations reloaded.");
+    }
+
+    /**
+     * Reloads a single registered file from disk.
+     *
+     * @param fileName registered file name
+     * @throws IllegalArgumentException if the file is not registered
+     */
+    public void reload(String fileName) {
+        reload(getOrThrow(fileName));
+    }
+
+    private void reload(ManagedConfig cfg) {
+        try {
+            cfg.reload();
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[ConfigFileManager] Failed to reload '" + cfg.getFileName() + "'", e);
+        }
+    }
+
+    /**
+     * Re-scans a watched directory and reloads all YAML files found inside it.
+     * New files added since the last scan are picked up automatically.
+     *
+     * @param dirPath directory path as passed to {@link #watchDirectory(String, ConfigOptions)}
+     * @throws IllegalArgumentException if the directory is not watched
+     */
+    public void reloadDirectory(String dirPath) {
+        UserDirectory dir = directories.get(dirPath);
+        if (dir == null) throw new IllegalArgumentException(
+                "[ConfigFileManager] Directory '" + dirPath + "' is not watched. Call watchDirectory() first.");
+        reloadDirectory(dir);
+    }
+
+    private void loadDirectory(UserDirectory dir) {
+        try { dir.load(); }
+        catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[ConfigFileManager] Failed to load directory '" + dir.getDirPath() + "'", e);
+        }
+    }
+
+    private void reloadDirectory(UserDirectory dir) {
+        try { dir.reload(); }
+        catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[ConfigFileManager] Failed to reload directory '" + dir.getDirPath() + "'", e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Saving
+    // -----------------------------------------------------------------------
+
+    /**
+     * Saves a single registered file to disk.
+     *
+     * <p><strong>Note:</strong> saving via Bukkit's {@code YamlConfiguration} strips comments.
+     * Prefer editing files programmatically only when necessary.
+     *
+     * @param fileName registered file name
+     */
+    public void save(String fileName) {
+        ManagedConfig cfg = getOrThrow(fileName);
+        try {
+            cfg.save();
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[ConfigFileManager] Failed to save '" + cfg.getFileName() + "'", e);
+        }
+    }
+
+    /**
+     * Saves all registered files to disk.
+     */
+    public void saveAll() {
+        for (ManagedConfig cfg : configs.values()) {
+            try { cfg.save(); }
+            catch (Exception e) {
+                plugin.getLogger().log(Level.SEVERE,
+                        "[ConfigFileManager] Failed to save '" + cfg.getFileName() + "'", e);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Access – explicit files
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the {@link ManagedConfig} for a registered file.
+     *
+     * @param fileName registered file name
+     * @return the managed config
+     * @throws IllegalArgumentException if the file is not registered
+     */
+    public ManagedConfig get(String fileName) {
+        return getOrThrow(fileName);
+    }
+
+    /**
+     * Returns {@code true} if the given file is registered.
+     */
+    public boolean isRegistered(String fileName) {
+        return configs.containsKey(fileName);
+    }
+
+    /**
+     * Returns an unmodifiable view of all explicitly registered configurations.
+     */
+    public Map<String, ManagedConfig> getAll() {
+        return Collections.unmodifiableMap(configs);
+    }
+
+    /**
+     * Unregisters a file from this manager without deleting it from disk.
+     *
+     * @param fileName registered file name
+     */
+    public void unregister(String fileName) {
+        configs.remove(fileName);
+    }
+
+    // -----------------------------------------------------------------------
+    // Access – user directories
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns all {@link ManagedConfig} instances currently loaded from a watched directory.
+     *
+     * @param dirPath directory path as passed to {@link #watchDirectory}
+     * @return unmodifiable collection of loaded configs (may be empty if the directory is empty)
+     * @throws IllegalArgumentException if the directory is not watched
+     */
+    public Collection<ManagedConfig> getDirectory(String dirPath) {
+        UserDirectory dir = directories.get(dirPath);
+        if (dir == null) throw new IllegalArgumentException(
+                "[ConfigFileManager] Directory '" + dirPath + "' is not watched. Call watchDirectory() first.");
+        return dir.getConfigs();
+    }
+
+    /**
+     * Returns a specific file from a watched directory, looked up by file name.
+     *
+     * @param dirPath  directory path as passed to {@link #watchDirectory}
+     * @param fileName file name relative to the directory (e.g. {@code "en_US.yml"})
+     * @return the config, or {@link Optional#empty()} if the file was not found in the directory
+     */
+    public Optional<ManagedConfig> getFromDirectory(String dirPath, String fileName) {
+        UserDirectory dir = directories.get(dirPath);
+        if (dir == null) throw new IllegalArgumentException(
+                "[ConfigFileManager] Directory '" + dirPath + "' is not watched. Call watchDirectory() first.");
+        return dir.getConfig(fileName);
+    }
+
+    /**
+     * Returns {@code true} if the given directory path is being watched.
+     */
+    public boolean isWatched(String dirPath) {
+        return directories.containsKey(dirPath);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal
+    // -----------------------------------------------------------------------
+
+    private ManagedConfig getOrThrow(String fileName) {
+        ManagedConfig cfg = configs.get(fileName);
+        if (cfg == null) throw new IllegalArgumentException(
+                "[ConfigFileManager] File '" + fileName + "' is not registered. Call register() first.");
+        return cfg;
+    }
+}

--- a/src/main/java/dev/notmarra/notlib/file/ConfigFormat.java
+++ b/src/main/java/dev/notmarra/notlib/file/ConfigFormat.java
@@ -1,0 +1,25 @@
+package dev.notmarra.notlib.file;
+
+/**
+ * Supported configuration file formats.
+ *
+ * <p>Currently only YAML is supported ({@code .yml} / {@code .yaml}).
+ */
+public enum ConfigFormat {
+    YAML;
+
+    /**
+     * Detects the format from the file name extension.
+     *
+     * @param fileName file name or relative path (e.g. {@code "config.yml"})
+     * @return the detected format
+     * @throws IllegalArgumentException for unsupported extensions
+     */
+    public static ConfigFormat detect(String fileName) {
+        String lower = fileName.toLowerCase();
+        if (lower.endsWith(".yml") || lower.endsWith(".yaml")) return YAML;
+        throw new IllegalArgumentException(
+                "[ConfigFileManager] Unsupported file format: '" + fileName +
+                        "'. Supported extensions: .yml, .yaml");
+    }
+}

--- a/src/main/java/dev/notmarra/notlib/file/ConfigOptions.java
+++ b/src/main/java/dev/notmarra/notlib/file/ConfigOptions.java
@@ -1,0 +1,173 @@
+package dev.notmarra.notlib.file;
+
+/**
+ * Per-file options controlling how a {@link ManagedConfig} is managed.
+ *
+ * <h3>Example:</h3>
+ * <pre>{@code
+ * ConfigOptions opts = ConfigOptions.builder()
+ *     .autoUpdate(true)
+ *     .preserveComments(true)
+ *     .seedFile("languages/en_US.yml")
+ *     .build();
+ * cfm.watchDirectory("languages", opts);
+ * }</pre>
+ */
+public class ConfigOptions {
+
+    /**
+     * Whether missing keys should be added from the resource template on load/reload.
+     * Existing user values are always preserved.
+     */
+    private final boolean autoUpdate;
+
+    /**
+     * Whether YAML comments from the resource template are preserved in the output file
+     * during an auto-update pass. Has no effect when {@code autoUpdate} is {@code false}.
+     */
+    private final boolean preserveComments;
+
+    /**
+     * Whether the file should be copied from plugin resources if it does not exist on disk.
+     * For watched directories this doubles as the "seed file" path option.
+     */
+    private final boolean copyFromResources;
+
+    /**
+     * Whether added keys are logged at INFO level during auto-update.
+     */
+    private final boolean logAddedKeys;
+
+    /**
+     * Optional resource path of a seed file to copy into a watched directory on first run.
+     * Gives users an example file to copy and customise.
+     * {@code null} means no seed file.
+     *
+     * <p>Example: if the directory is {@code "languages"} and the seed is
+     * {@code "languages/en_US.yml"}, that resource is copied once on startup.
+     */
+    private final String seedFile;
+
+    private ConfigOptions(Builder builder) {
+        this.autoUpdate        = builder.autoUpdate;
+        this.preserveComments  = builder.preserveComments;
+        this.copyFromResources = builder.copyFromResources;
+        this.logAddedKeys      = builder.logAddedKeys;
+        this.seedFile          = builder.seedFile;
+    }
+
+    // -----------------------------------------------------------------------
+    // Factories
+    // -----------------------------------------------------------------------
+
+    /**
+     * Default options: {@code autoUpdate=true}, {@code preserveComments=true},
+     * {@code copyFromResources=true}, {@code logAddedKeys=true}, no seed file.
+     */
+    public static ConfigOptions defaults() {
+        return builder().build();
+    }
+
+    /**
+     * Options suitable for user-managed files: auto-update disabled, no resource copy.
+     * Files are loaded as-is without any template merging.
+     */
+    public static ConfigOptions userManaged() {
+        return builder().autoUpdate(false).copyFromResources(false).build();
+    }
+
+    /**
+     * Options without auto-update; the file is only copied from resources if missing.
+     */
+    public static ConfigOptions noAutoUpdate() {
+        return builder().autoUpdate(false).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // -----------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------
+
+    /** @see Builder#autoUpdate(boolean) */
+    public boolean isAutoUpdate() { return autoUpdate; }
+
+    /** @see Builder#preserveComments(boolean) */
+    public boolean isPreserveComments() { return preserveComments; }
+
+    /** @see Builder#copyFromResources(boolean) */
+    public boolean isCopyFromResources() { return copyFromResources; }
+
+    /** @see Builder#logAddedKeys(boolean) */
+    public boolean isLogAddedKeys() { return logAddedKeys; }
+
+    /** @see Builder#seedFile(String) */
+    public String getSeedFile() { return seedFile; }
+
+    // -----------------------------------------------------------------------
+    // Builder
+    // -----------------------------------------------------------------------
+
+    public static class Builder {
+        private boolean autoUpdate        = true;
+        private boolean preserveComments  = true;
+        private boolean copyFromResources = true;
+        private boolean logAddedKeys      = true;
+        private String  seedFile          = null;
+
+        private Builder() {}
+
+        /**
+         * When {@code true} (default), missing keys are added from the resource template
+         * on every load and reload while preserving the user's own values.
+         */
+        public Builder autoUpdate(boolean autoUpdate) {
+            this.autoUpdate = autoUpdate;
+            return this;
+        }
+
+        /**
+         * When {@code true} (default), YAML comments from the resource template are
+         * written to the output file during an auto-update pass.
+         */
+        public Builder preserveComments(boolean preserveComments) {
+            this.preserveComments = preserveComments;
+            return this;
+        }
+
+        /**
+         * When {@code true} (default), the file is copied from plugin resources the first
+         * time it is loaded if it does not yet exist on disk.
+         */
+        public Builder copyFromResources(boolean copyFromResources) {
+            this.copyFromResources = copyFromResources;
+            return this;
+        }
+
+        /**
+         * When {@code true} (default), each key added during auto-update is logged at INFO level.
+         */
+        public Builder logAddedKeys(boolean logAddedKeys) {
+            this.logAddedKeys = logAddedKeys;
+            return this;
+        }
+
+        /**
+         * Resource path of an example file to copy into a watched directory on first startup.
+         * Has no effect on explicitly registered files.
+         *
+         * <p>Example: {@code .seedFile("languages/en_US.yml")} copies that resource
+         * into the {@code languages/} directory so users have a template to start from.
+         */
+        public Builder seedFile(String resourcePath) {
+            this.seedFile = resourcePath;
+            return this;
+        }
+
+        public ConfigOptions build() {
+            return new ConfigOptions(this);
+        }
+    }
+}

--- a/src/main/java/dev/notmarra/notlib/file/ManagedConfig.java
+++ b/src/main/java/dev/notmarra/notlib/file/ManagedConfig.java
@@ -1,0 +1,192 @@
+package dev.notmarra.notlib.file;
+
+import dev.notmarra.notlib.file.updater.YamlConfigUpdater;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.*;
+import java.util.logging.Level;
+
+/**
+ * Represents a single managed configuration file.
+ *
+ * <p>Provides:
+ * <ul>
+ *   <li>Value access via Bukkit's {@link FileConfiguration} API</li>
+ *   <li>Auto-update: missing keys added from the resource template, user values preserved</li>
+ *   <li>Comment and block scalar preservation during update</li>
+ *   <li>Reload from disk</li>
+ * </ul>
+ *
+ * <p>Instances are created exclusively by {@link ConfigFileManager} and {@link dev.library.config.userfiles.UserDirectory}.
+ */
+public class ManagedConfig {
+
+    private final JavaPlugin    plugin;
+    private final String        fileName;
+    private final File          file;
+    private final ConfigFormat  format;
+    private final ConfigOptions options;
+
+    private FileConfiguration yamlConfig;
+
+    // -----------------------------------------------------------------------
+    // Constructor (package-private – created by ConfigFileManager / UserDirectory)
+    // -----------------------------------------------------------------------
+
+    ManagedConfig(JavaPlugin plugin, String fileName, File file, ConfigFormat format, ConfigOptions options) {
+        this.plugin   = plugin;
+        this.fileName = fileName;
+        this.file     = file;
+        this.format   = format;
+        this.options  = options;
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * Loads the file from disk. If the file does not exist and
+     * {@link ConfigOptions#isCopyFromResources()} is {@code true} it is copied
+     * from plugin resources first. Then, if {@link ConfigOptions#isAutoUpdate()}
+     * is {@code true}, missing keys are merged in from the resource template.
+     */
+    void load() throws IOException {
+        ensureFileExists();
+        readFromDisk();
+        if (options.isAutoUpdate()) runAutoUpdate();
+    }
+
+    /**
+     * Reloads the file from disk and re-runs auto-update if enabled.
+     * Does not re-copy from resources.
+     */
+    void reload() throws IOException {
+        readFromDisk();
+        if (options.isAutoUpdate()) runAutoUpdate();
+        plugin.getLogger().info("[ConfigFileManager] Reloaded '" + fileName + "'.");
+    }
+
+    /**
+     * Saves the current in-memory state to disk via Bukkit's YAML serialiser.
+     *
+     * <p><strong>Warning:</strong> Bukkit's {@link YamlConfiguration#save} discards all
+     * comments. Only call this when programmatically mutating values via {@link #set}.
+     */
+    void save() throws IOException {
+        if (yamlConfig != null) yamlConfig.save(file);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal – file initialisation
+    // -----------------------------------------------------------------------
+
+    private void ensureFileExists() throws IOException {
+        if (file.exists()) return;
+
+        if (options.isCopyFromResources()) {
+            copyFromResources(fileName);
+        } else {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+        }
+    }
+
+    /**
+     * Copies a resource from the plugin jar to {@link #file}.
+     *
+     * @param resourcePath path inside the jar (e.g. {@code "config.yml"})
+     */
+    void copyFromResources(String resourcePath) throws IOException {
+        InputStream resource = plugin.getResource(resourcePath);
+        if (resource == null) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+            plugin.getLogger().warning("[ConfigFileManager] Resource '" + resourcePath +
+                    "' not found in plugin jar. Created empty file at '" + fileName + "'.");
+            return;
+        }
+
+        file.getParentFile().mkdirs();
+        try (InputStream in = resource; OutputStream out = new FileOutputStream(file)) {
+            byte[] buf = new byte[4096];
+            int len;
+            while ((len = in.read(buf)) > 0) out.write(buf, 0, len);
+        }
+        plugin.getLogger().info("[ConfigFileManager] Created '" + fileName + "' from resources.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal – read & auto-update
+    // -----------------------------------------------------------------------
+
+    private void readFromDisk() {
+        yamlConfig = YamlConfiguration.loadConfiguration(file);
+    }
+
+    private void runAutoUpdate() {
+        InputStream resource = plugin.getResource(fileName);
+        if (resource == null) return; // No template in jar – nothing to merge
+
+        try {
+            new YamlConfigUpdater(plugin, fileName, file, options).update(resource);
+            readFromDisk(); // Refresh so yamlConfig reflects newly added keys
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING,
+                    "[ConfigFileManager] Auto-update failed for '" + fileName + "'", e);
+        } finally {
+            try { resource.close(); } catch (IOException ignored) {}
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Value access
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the underlying Bukkit {@link FileConfiguration} for full API access.
+     *
+     * @throws IllegalStateException if the file has not been loaded yet
+     */
+    public FileConfiguration yaml() {
+        if (yamlConfig == null) throw new IllegalStateException(
+                "[ConfigFileManager] File '" + fileName + "' has not been loaded yet. Call loadAll() first.");
+        return yamlConfig;
+    }
+
+    /** @see FileConfiguration#getString(String, String) */
+    public String getString(String path, String fallback)    { return yaml().getString(path, fallback); }
+
+    /** @see FileConfiguration#getInt(String, int) */
+    public int getInt(String path, int fallback)             { return yaml().getInt(path, fallback); }
+
+    /** @see FileConfiguration#getBoolean(String, boolean) */
+    public boolean getBoolean(String path, boolean fallback) { return yaml().getBoolean(path, fallback); }
+
+    /** @see FileConfiguration#getDouble(String, double) */
+    public double getDouble(String path, double fallback)    { return yaml().getDouble(path, fallback); }
+
+    /**
+     * Sets a value in the in-memory configuration.
+     * Call {@link ConfigFileManager#save(String)} to persist the change to disk.
+     */
+    public void set(String path, Object value) { yaml().set(path, value); }
+
+    // -----------------------------------------------------------------------
+    // Metadata
+    // -----------------------------------------------------------------------
+
+    /** File name / registration key (e.g. {@code "config.yml"} or {@code "languages/de_DE.yml"}). */
+    public String getFileName()       { return fileName; }
+
+    /** The {@link File} handle pointing to the file on disk. */
+    public File getFile()             { return file; }
+
+    /** Detected file format. */
+    public ConfigFormat getFormat()   { return format; }
+
+    /** Options controlling how this file is managed. */
+    public ConfigOptions getOptions() { return options; }
+}

--- a/src/main/java/dev/notmarra/notlib/file/UserDirectory.java
+++ b/src/main/java/dev/notmarra/notlib/file/UserDirectory.java
@@ -1,0 +1,214 @@
+package dev.notmarra.notlib.file;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+/**
+ * Manages a directory whose YAML files are created and maintained by users at runtime.
+ *
+ * <p>Typical use cases:
+ * <ul>
+ *   <li><strong>Language files</strong> – users drop {@code en_US.yml}, {@code de_DE.yml}, etc.
+ *       into a {@code languages/} directory.</li>
+ *   <li><strong>Arena configs</strong> – each arena lives in its own YAML file inside
+ *       {@code arenas/}.</li>
+ *   <li><strong>Reward packs</strong> – community-made packs placed in {@code rewards/}.</li>
+ * </ul>
+ *
+ * <h3>Behaviour:</h3>
+ * <ol>
+ *   <li>The directory is created on first load if it does not exist.</li>
+ *   <li>If a {@link ConfigOptions#getSeedFile() seed file} is configured and the directory
+ *       is empty, that resource is copied in as a starting template.</li>
+ *   <li>Every {@code *.yml} / {@code *.yaml} file in the directory (non-recursive) is
+ *       loaded as a {@link ManagedConfig} with the options supplied to the directory.</li>
+ *   <li>On reload, previously loaded configs are refreshed and any newly added files are
+ *       picked up automatically.</li>
+ * </ol>
+ *
+ * <p>Instances are created exclusively by {@link dev.library.config.ConfigFileManager}.
+ */
+public class UserDirectory {
+
+    private final JavaPlugin    plugin;
+    private final String        dirPath;   // relative to plugin data folder
+    private final File          dir;
+    private final ConfigOptions options;
+
+    /** Currently loaded configs, keyed by their file name (e.g. "en_US.yml"). */
+    private final Map<String, ManagedConfig> configs = new LinkedHashMap<>();
+
+    // -----------------------------------------------------------------------
+    // Constructor (package-private)
+    // -----------------------------------------------------------------------
+
+    public UserDirectory(JavaPlugin plugin, String dirPath, File dir, ConfigOptions options) {
+        this.plugin  = plugin;
+        this.dirPath = dirPath;
+        this.dir     = dir;
+        this.options = options;
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates the directory if needed, copies the seed file on first run,
+     * then loads all YAML files found inside.
+     */
+    public void load() throws IOException {
+        ensureDirectoryExists();
+        copySeedFileIfEmpty();
+        scanAndLoad();
+        plugin.getLogger().info("[ConfigFileManager] Loaded " + configs.size() +
+                " file(s) from directory '" + dirPath + "'.");
+    }
+
+    /**
+     * Re-scans the directory and reloads all YAML files.
+     * Files added since the last scan are picked up automatically.
+     * Files that no longer exist on disk are removed from the cache.
+     */
+    public void reload() throws IOException {
+        ensureDirectoryExists();
+        scanAndLoad();
+        plugin.getLogger().info("[ConfigFileManager] Reloaded " + configs.size() +
+                " file(s) from directory '" + dirPath + "'.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal – directory setup
+    // -----------------------------------------------------------------------
+
+    private void ensureDirectoryExists() {
+        if (!dir.exists()) {
+            dir.mkdirs();
+            plugin.getLogger().info("[ConfigFileManager] Created directory '" + dirPath + "'.");
+        }
+    }
+
+    /**
+     * Copies the configured seed file from plugin resources into the directory
+     * if the directory is currently empty. This gives users a starting template.
+     */
+    private void copySeedFileIfEmpty() {
+        String seedResource = options.getSeedFile();
+        if (seedResource == null) return;
+
+        File[] existing = dir.listFiles(f -> isYaml(f.getName()));
+        if (existing != null && existing.length > 0) return; // Already has files – skip
+
+        InputStream resource = plugin.getResource(seedResource);
+        if (resource == null) {
+            plugin.getLogger().warning("[ConfigFileManager] Seed file resource '" + seedResource +
+                    "' not found in plugin jar. Skipping seed copy for '" + dirPath + "'.");
+            return;
+        }
+
+        // Determine destination file name (last segment of the resource path)
+        String destName = seedResource.contains("/")
+                ? seedResource.substring(seedResource.lastIndexOf('/') + 1)
+                : seedResource;
+        File dest = new File(dir, destName);
+
+        try (InputStream in = resource; OutputStream out = new FileOutputStream(dest)) {
+            byte[] buf = new byte[4096];
+            int len;
+            while ((len = in.read(buf)) > 0) out.write(buf, 0, len);
+            plugin.getLogger().info("[ConfigFileManager] Copied seed file '" + destName +
+                    "' into '" + dirPath + "'.");
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.WARNING,
+                    "[ConfigFileManager] Failed to copy seed file into '" + dirPath + "'", e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal – scanning
+    // -----------------------------------------------------------------------
+
+    /**
+     * Scans the directory for YAML files (non-recursive), loads new ones,
+     * reloads existing ones, and removes stale entries for deleted files.
+     */
+    private void scanAndLoad() {
+        File[] found = dir.listFiles(f -> f.isFile() && isYaml(f.getName()));
+        if (found == null) found = new File[0];
+
+        // Build a set of currently present file names
+        Set<String> present = Arrays.stream(found)
+                .map(File::getName)
+                .collect(Collectors.toSet());
+
+        // Remove configs for files that were deleted
+        configs.keySet().removeIf(name -> !present.contains(name));
+
+        // Load new files / reload existing ones
+        for (File file : found) {
+            String name = file.getName();
+            // Relative path for logging and registration (e.g. "languages/en_US.yml")
+            String relativePath = dirPath + "/" + name;
+
+            ManagedConfig existing = configs.get(name);
+            if (existing == null) {
+                // New file – create and load
+                ManagedConfig cfg = new ManagedConfig(
+                        plugin, relativePath, file, ConfigFormat.detect(name), options);
+                try {
+                    cfg.load();
+                    configs.put(name, cfg);
+                } catch (Exception e) {
+                    plugin.getLogger().log(Level.WARNING,
+                            "[ConfigFileManager] Failed to load user file '" + relativePath + "'", e);
+                }
+            } else {
+                // Existing – reload
+                try {
+                    existing.reload();
+                } catch (Exception e) {
+                    plugin.getLogger().log(Level.WARNING,
+                            "[ConfigFileManager] Failed to reload user file '" + relativePath + "'", e);
+                }
+            }
+        }
+    }
+
+    private static boolean isYaml(String name) {
+        String lower = name.toLowerCase();
+        return lower.endsWith(".yml") || lower.endsWith(".yaml");
+    }
+
+    // -----------------------------------------------------------------------
+    // Access
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns all currently loaded configs from this directory.
+     *
+     * @return unmodifiable collection; may be empty if the directory contains no YAML files
+     */
+    public Collection<ManagedConfig> getConfigs() {
+        return Collections.unmodifiableCollection(configs.values());
+    }
+
+    /**
+     * Returns a config by its file name (e.g. {@code "en_US.yml"}).
+     *
+     * @param fileName file name relative to the directory
+     * @return the config wrapped in an {@link Optional}, or empty if not found
+     */
+    public Optional<ManagedConfig> getConfig(String fileName) {
+        return Optional.ofNullable(configs.get(fileName));
+    }
+
+    /** Returns the directory path relative to the plugin data folder. */
+    public String getDirPath() { return dirPath; }
+
+    /** Returns the {@link File} handle for the directory on disk. */
+    public File getDir()       { return dir; }
+}

--- a/src/main/java/dev/notmarra/notlib/file/updater/YamlConfigUpdater.java
+++ b/src/main/java/dev/notmarra/notlib/file/updater/YamlConfigUpdater.java
@@ -1,0 +1,403 @@
+package dev.notmarra.notlib.file.updater;
+
+import dev.notmarra.notlib.file.ConfigOptions;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Performs a "smart update" of a YAML configuration file on disk:
+ *
+ * <ol>
+ *   <li>Parses the resource template (keys, values, comments, block scalars).</li>
+ *   <li>Parses the existing user file the same way.</li>
+ *   <li>Builds the output: template structure + user values where they exist +
+ *       template defaults for any missing keys.</li>
+ *   <li>Comments and block scalars from the template are preserved in the output.</li>
+ * </ol>
+ *
+ * <h3>Supported value types:</h3>
+ * <ul>
+ *   <li>Inline values:             {@code key: value}</li>
+ *   <li>Literal block scalar:      {@code key: |} (newlines preserved)</li>
+ *   <li>Folded block scalar:       {@code key: >} (newlines folded to spaces)</li>
+ *   <li>Block scalar modifiers:    {@code |-}, {@code |+}, {@code >-}, {@code >+}</li>
+ *   <li>Sequence blocks (lists):   {@code - item}</li>
+ *   <li>Nested mappings (sections)</li>
+ * </ul>
+ *
+ * <h3>Implementation note:</h3>
+ * SnakeYAML discards all comments during serialisation, so this updater operates purely
+ * at the text level without delegating serialisation to SnakeYAML.
+ */
+public class YamlConfigUpdater {
+
+    private final JavaPlugin    plugin;
+    private final String        fileName;
+    private final File          diskFile;
+    private final ConfigOptions options;
+
+    public YamlConfigUpdater(JavaPlugin plugin, String fileName, File diskFile, ConfigOptions options) {
+        this.plugin   = plugin;
+        this.fileName = fileName;
+        this.diskFile = diskFile;
+        this.options  = options;
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /**
+     * Runs the update. Adds missing keys from the template, preserves user values and comments.
+     *
+     * @param resourceStream template stream from plugin resources (closed by the caller)
+     */
+    public void update(InputStream resourceStream) throws IOException {
+        List<String> templateLines = readLines(resourceStream);
+        List<String> diskLines     = readLines(new FileInputStream(diskFile));
+
+        List<YamlEntry> templateEntries = parse(templateLines);
+        List<YamlEntry> diskEntries     = parse(diskLines);
+
+        // Index disk values by full dot-notation key for fast lookup
+        Map<String, YamlEntry> diskIndex = new LinkedHashMap<>();
+        for (YamlEntry e : diskEntries) {
+            if (e.fullKey != null && e.hasValue()) diskIndex.put(e.fullKey, e);
+        }
+
+        // Collect missing keys for the log message
+        List<String> missingKeys = new ArrayList<>();
+        for (YamlEntry e : templateEntries) {
+            if (e.fullKey != null && e.hasValue() && !diskIndex.containsKey(e.fullKey))
+                missingKeys.add(e.fullKey);
+        }
+
+        if (missingKeys.isEmpty()) return;
+
+        if (options.isLogAddedKeys()) {
+            plugin.getLogger().info("[ConfigFileManager] Auto-update '" + fileName
+                    + "': adding " + missingKeys.size() + " missing key(s): " + missingKeys);
+        }
+
+        writeLines(buildOutput(templateEntries, diskIndex));
+    }
+
+    // -----------------------------------------------------------------------
+    // Parser  →  List<YamlEntry>
+    // -----------------------------------------------------------------------
+
+    /**
+     * Parses a list of raw lines into structured {@link YamlEntry} blocks.
+     *
+     * <p>Each entry represents one logical YAML element: a blank line, a comment,
+     * an inline key-value pair, a block scalar (key line + all content lines),
+     * a section header (nested mapping), or a raw line (list item, etc.).
+     */
+    private List<YamlEntry> parse(List<String> lines) {
+        List<YamlEntry> entries    = new ArrayList<>();
+        Deque<String>   secStack   = new ArrayDeque<>();
+        int prevKeyIndent = 0;
+        int i = 0;
+
+        while (i < lines.size()) {
+            String line    = lines.get(i);
+            String trimmed = line.trim();
+
+            // Blank line
+            if (trimmed.isEmpty()) {
+                entries.add(YamlEntry.blank(line));
+                i++;
+                continue;
+            }
+
+            // Comment
+            if (trimmed.startsWith("#")) {
+                entries.add(YamlEntry.comment(line));
+                i++;
+                continue;
+            }
+
+            // Sequence item – not parsed as a key, belongs to the parent mapping
+            if (trimmed.startsWith("- ") || trimmed.equals("-")) {
+                entries.add(YamlEntry.raw(line));
+                i++;
+                continue;
+            }
+
+            // Key: value  or  section header
+            if (trimmed.contains(":")) {
+                int    indent = getIndent(line);
+                String[] kv  = trimmed.split(":", 2);
+                String  key  = kv[0].trim();
+                String  rest = (kv.length > 1 ? kv[1] : "").trim();
+
+                updateSectionStack(secStack, key, indent, prevKeyIndent);
+                prevKeyIndent = indent;
+                String fullKey = buildFullKey(secStack);
+
+                // Block scalar indicator: | or > with optional modifier and/or inline comment
+                if (rest.matches("[|>][\\-+]?(?:\\s*#.*)?")) {
+                    List<String> blockLines = new ArrayList<>();
+                    blockLines.add(line);
+
+                    int j = i + 1;
+                    while (j < lines.size()) {
+                        String next = lines.get(j);
+                        // Block content: blank lines or lines indented deeper than the key
+                        if (next.trim().isEmpty() || getIndent(next) > indent) {
+                            blockLines.add(next);
+                            j++;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // Strip trailing blank lines – they belong to the next key's separation
+                    while (blockLines.size() > 1 && blockLines.get(blockLines.size() - 1).trim().isEmpty())
+                        blockLines.remove(blockLines.size() - 1);
+
+                    entries.add(YamlEntry.blockScalar(fullKey, key, indent, blockLines));
+                    i = j;
+                    continue;
+                }
+
+                // Section header (mapping with no inline value)
+                if (stripInlineComment(rest).isEmpty()) {
+                    entries.add(YamlEntry.section(fullKey, key, indent, line));
+                    i++;
+                    continue;
+                }
+
+                // Plain inline value
+                entries.add(YamlEntry.inline(fullKey, key, indent, line));
+                i++;
+                continue;
+            }
+
+            // Fallthrough – unrecognised line (pass through unchanged)
+            entries.add(YamlEntry.raw(line));
+            i++;
+        }
+
+        return entries;
+    }
+
+    // -----------------------------------------------------------------------
+    // Output builder
+    // -----------------------------------------------------------------------
+
+    /**
+     * Walks the template entries and decides for each one what to emit:
+     *
+     * <ul>
+     *   <li>BLANK / RAW → copy from template.</li>
+     *   <li>COMMENT → copy if {@link ConfigOptions#isPreserveComments()}.</li>
+     *   <li>SECTION → always copy (structural).</li>
+     *   <li>INLINE – user has inline → substitute user value, keep template's inline comment.</li>
+     *   <li>INLINE – user has block scalar → emit the user's whole block.</li>
+     *   <li>INLINE – missing → emit from template.</li>
+     *   <li>BLOCK_SCALAR – user has block → emit the user's whole block.</li>
+     *   <li>BLOCK_SCALAR – user has inline → emit user's inline.</li>
+     *   <li>BLOCK_SCALAR – missing → emit the whole template block.</li>
+     * </ul>
+     */
+    private List<String> buildOutput(List<YamlEntry> template, Map<String, YamlEntry> diskIndex) {
+        List<String> out = new ArrayList<>();
+
+        for (YamlEntry te : template) {
+            switch (te.type) {
+
+                case BLANK:
+                case RAW:
+                    out.add(te.lines.get(0));
+                    break;
+
+                case COMMENT:
+                    if (options.isPreserveComments()) out.add(te.lines.get(0));
+                    break;
+
+                case SECTION:
+                    out.add(te.lines.get(0));
+                    break;
+
+                case INLINE: {
+                    YamlEntry disk = diskIndex.get(te.fullKey);
+                    if (disk == null) {
+                        out.add(te.lines.get(0));                    // missing → template default
+                    } else if (disk.type == EntryType.BLOCK_SCALAR) {
+                        out.addAll(disk.lines);                      // user converted to block scalar
+                    } else {
+                        // User has an inline value → substitute it, keep template's inline comment
+                        String userValue     = extractInlineValue(disk.lines.get(0));
+                        String inlineComment = extractInlineComment(te.lines.get(0));
+                        out.add(rebuildInlineLine(te.lines.get(0), te.key, userValue, inlineComment));
+                    }
+                    break;
+                }
+
+                case BLOCK_SCALAR: {
+                    YamlEntry disk = diskIndex.get(te.fullKey);
+                    if (disk == null) {
+                        out.addAll(te.lines);                        // missing → whole template block
+                    } else if (disk.type == EntryType.INLINE) {
+                        out.add(disk.lines.get(0));                  // user converted to inline
+                    } else {
+                        out.addAll(disk.lines);                      // user's own block scalar
+                    }
+                    break;
+                }
+            }
+        }
+
+        return out;
+    }
+
+    // -----------------------------------------------------------------------
+    // Line helpers
+    // -----------------------------------------------------------------------
+
+    /** Returns the value portion of an inline line (everything after the first {@code :}). */
+    private String extractInlineValue(String line) {
+        int colon = line.indexOf(':');
+        return colon < 0 ? "" : line.substring(colon + 1).trim();
+    }
+
+    /**
+     * Rebuilds an inline line preserving the original indentation and key,
+     * substituting {@code userValue} and appending the template's inline comment.
+     */
+    private String rebuildInlineLine(String templateLine, String key, String userValue, String inlineComment) {
+        String prefix      = " ".repeat(getIndent(templateLine));
+        String commentPart = inlineComment.isEmpty() ? "" : "  " + inlineComment;
+        return prefix + key + ": " + userValue + commentPart;
+    }
+
+    // -----------------------------------------------------------------------
+    // Section-stack helpers
+    // -----------------------------------------------------------------------
+
+    private void updateSectionStack(Deque<String> stack, String key, int indent, int prevIndent) {
+        if (stack.isEmpty()) { stack.push(key); return; }
+
+        if (indent > prevIndent) {
+            stack.push(key);                                         // descend into sub-mapping
+        } else if (indent < prevIndent) {
+            int step  = Math.max(1, prevIndent - indent);
+            int steps = (prevIndent - indent) / step + 1;
+            for (int i = 0; i < steps && !stack.isEmpty(); i++) stack.pop();
+            stack.push(key);
+        } else {
+            stack.pop();
+            stack.push(key);                                         // sibling key – replace top
+        }
+    }
+
+    private String buildFullKey(Deque<String> stack) {
+        List<String> parts = new ArrayList<>(stack);
+        Collections.reverse(parts);
+        return String.join(".", parts);
+    }
+
+    private int getIndent(String line) {
+        int n = 0;
+        for (char c : line.toCharArray()) { if (c == ' ') n++; else break; }
+        return n;
+    }
+
+    // -----------------------------------------------------------------------
+    // Comment helpers
+    // -----------------------------------------------------------------------
+
+    /** Returns the inline comment from a line (from the first {@code ' #'} outside quotes), or {@code ""}. */
+    private String extractInlineComment(String line) {
+        boolean inQ = false; char qc = 0;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (!inQ && (c == '\'' || c == '"'))                         { inQ = true;  qc = c; }
+            else if (inQ && c == qc)                                     { inQ = false; }
+            else if (!inQ && c == '#' && i > 0 && line.charAt(i-1)==' '){ return line.substring(i); }
+        }
+        return "";
+    }
+
+    /** Strips the inline comment from a value string. */
+    private String stripInlineComment(String value) {
+        boolean inQ = false; char qc = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (!inQ && (c == '\'' || c == '"'))                         { inQ = true;  qc = c; }
+            else if (inQ && c == qc)                                     { inQ = false; }
+            else if (!inQ && c == '#' && i > 0 && value.charAt(i-1)==' '){ return value.substring(0, i).trim(); }
+        }
+        return value;
+    }
+
+    // -----------------------------------------------------------------------
+    // I/O
+    // -----------------------------------------------------------------------
+
+    private List<String> readLines(InputStream stream) throws IOException {
+        List<String> lines = new ArrayList<>();
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = r.readLine()) != null) lines.add(line);
+        }
+        return lines;
+    }
+
+    private void writeLines(List<String> lines) throws IOException {
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(diskFile), StandardCharsets.UTF_8)) {
+            for (String line : lines) { w.write(line); w.write(System.lineSeparator()); }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal data types
+    // -----------------------------------------------------------------------
+
+    private enum EntryType { BLANK, COMMENT, SECTION, INLINE, BLOCK_SCALAR, RAW }
+
+    /**
+     * One logical element of a YAML file.
+     *
+     * <p>For {@code BLOCK_SCALAR}: {@code lines} holds the key line plus all content lines.
+     * For all other types: {@code lines} holds exactly one line.
+     */
+    private static class YamlEntry {
+        final EntryType    type;
+        final String       fullKey;   // dot-notation; null for BLANK / COMMENT / RAW
+        final String       key;       // bare key without section prefix
+        final int          indent;
+        final List<String> lines;     // BLOCK_SCALAR: whole block; others: single line
+
+        private YamlEntry(EntryType type, String fullKey, String key, int indent, List<String> lines) {
+            this.type    = type;
+            this.fullKey = fullKey;
+            this.key     = key;
+            this.indent  = indent;
+            this.lines   = Collections.unmodifiableList(lines);
+        }
+
+        static YamlEntry blank(String line)   { return new YamlEntry(EntryType.BLANK,   null, null, 0, List.of(line)); }
+        static YamlEntry comment(String line) { return new YamlEntry(EntryType.COMMENT, null, null, 0, List.of(line)); }
+        static YamlEntry raw(String line)     { return new YamlEntry(EntryType.RAW,     null, null, 0, List.of(line)); }
+
+        static YamlEntry section(String fk, String key, int indent, String line) {
+            return new YamlEntry(EntryType.SECTION, fk, key, indent, List.of(line));
+        }
+        static YamlEntry inline(String fk, String key, int indent, String line) {
+            return new YamlEntry(EntryType.INLINE, fk, key, indent, List.of(line));
+        }
+        static YamlEntry blockScalar(String fk, String key, int indent, List<String> blockLines) {
+            return new YamlEntry(EntryType.BLOCK_SCALAR, fk, key, indent, new ArrayList<>(blockLines));
+        }
+
+        /** {@code true} if this entry carries a real value (inline or block scalar). */
+        boolean hasValue() {
+            return type == EntryType.INLINE || type == EntryType.BLOCK_SCALAR;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a major refactor of the plugin configuration system, centralizing all config file management through a new `ConfigFileManager` (CFM). The changes simplify config access, improve reload handling, and add support for directory watching and user-extensible config files. Backwards compatibility is maintained for most public APIs, but internal config loading and registration logic is now routed through the CFM.

**Core configuration system refactor:**

- All config file loading, caching, and reloads are now handled by a single `ConfigFileManager` instance (`cfm`) in `NotPlugin`, replacing the previous ad-hoc `CONFIGS` map and manual file operations. This includes new methods for registering, loading, and reloading configs, as well as for watching directories for user-created YAML files. [[1]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL19-R264) [[2]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL222-R335)

- The `Configurable` base class is updated to work transparently with the new CFM, with improved Javadoc, clearer lifecycle hooks, and helper methods for accessing configs and triggering reloads.

**API and method improvements:**

- Existing config access and reload methods (`getSubConfig`, `reloadConfig`, `saveDefaultConfig`, etc.) are preserved for compatibility, but now delegate to the CFM under the hood. New methods are added for watching user directories and resource directories, making it easier to support user-extensible configuration. [[1]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL19-R264) [[2]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL222-R335)

- The registration process for `Configurable` instances is streamlined: registering a configurable automatically registers all its config paths with the CFM and triggers an initial reload.

**Other changes:**

- The project version is updated in `pom.xml` from `1.0-DEV` to `0.1.0-DEV`.

- The default IntelliJ inspection profile now enables the `JavadocReference` inspection as an error. (.idea/inspectionProfiles/Project_Default.xml)

**Most important changes:**

**Configuration system refactor:**
- Centralized all config file management in `NotPlugin` via a new `ConfigFileManager` (`cfm`), replacing previous manual config handling and enabling directory watching, auto-update, and improved reload notification. [[1]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL19-R264) [[2]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL222-R335)
- Refactored the `Configurable` class to integrate with the new CFM, added detailed Javadoc, and clarified lifecycle and config access methods.

**API improvements and compatibility:**
- Updated config access, reload, and registration methods in `NotPlugin` to use the CFM while maintaining backwards compatibility for existing plugins. Added new helpers for watching user and resource directories for config files. [[1]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL19-R264) [[2]](diffhunk://#diff-01449392ebaaf315c2e145353f8f8d39211886a11806fa7439a8f3d32784159aL222-R335)

**Project maintenance:**
- Updated project version in `pom.xml` to `0.1.0-DEV`.
- Enabled `JavadocReference` inspection as an error in the default IntelliJ project profile.