### PR TITLE
bug fixes

### DIFF
--- a/src/main/java/dev/notmarra/notlib/cache/CachedRepository.java
+++ b/src/main/java/dev/notmarra/notlib/cache/CachedRepository.java
@@ -6,14 +6,9 @@ import dev.notmarra.notlib.database.repository.EntityRepository;
 import dev.notmarra.notlib.database.repository.QueryBuilder;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -59,6 +54,7 @@ public class CachedRepository<K, V> {
     private final NotCache<K, V> cache;
     private final WriteStrategy writeStrategy;
     private final Field pkField;
+    private final Executor executor;
 
     // ── WRITE-BEHIND FLUSH ───────────────────────────────────────────────────
 
@@ -69,7 +65,8 @@ public class CachedRepository<K, V> {
 
     @SuppressWarnings("unchecked")
     private CachedRepository(Builder<K, V> b) {
-        this.repo = new EntityRepository<>(b.database, b.entityClass);
+        this.executor = b.executor;
+        this.repo = new EntityRepository<>(b.database, b.entityClass).withExecutor(b.executor);
         this.cache = b.cache;
         this.writeStrategy = b.writeStrategy;
 
@@ -115,7 +112,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Optional<V>> findByIdAsync(K id) {
-        return CompletableFuture.supplyAsync(() -> findById(id));
+        return CompletableFuture.supplyAsync(() -> findById(id), executor);
     }
 
     public List<V> findAll() {
@@ -125,7 +122,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<List<V>> findAllAsync() {
-        return CompletableFuture.supplyAsync(this::findAll);
+        return CompletableFuture.supplyAsync(this::findAll, executor);
     }
 
     public boolean exists(K id) {
@@ -134,7 +131,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Boolean> existsAsync(K id) {
-        return CompletableFuture.supplyAsync(() -> exists(id));
+        return CompletableFuture.supplyAsync(() -> exists(id), executor);
     }
 
     // ── INSERT ───────────────────────────────────────────────────────────────
@@ -157,7 +154,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Void> insertAsync(V entity) {
-        return CompletableFuture.runAsync(() -> insert(entity));
+        return CompletableFuture.runAsync(() -> insert(entity), executor);
     }
 
     public void insertAll(List<V> entities) {
@@ -177,7 +174,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Void> insertAllAsync(List<V> entities) {
-        return CompletableFuture.runAsync(() -> insertAll(entities));
+        return CompletableFuture.runAsync(() -> insertAll(entities), executor);
     }
 
     // ── UPDATE ───────────────────────────────────────────────────────────────
@@ -200,7 +197,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Void> updateAsync(V entity) {
-        return CompletableFuture.runAsync(() -> update(entity));
+        return CompletableFuture.runAsync(() -> update(entity), executor);
     }
 
     // ── UPSERT ───────────────────────────────────────────────────────────────
@@ -223,7 +220,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Void> upsertAsync(V entity) {
-        return CompletableFuture.runAsync(() -> upsert(entity));
+        return CompletableFuture.runAsync(() -> upsert(entity), executor);
     }
 
     // ── DELETE ───────────────────────────────────────────────────────────────
@@ -234,7 +231,7 @@ public class CachedRepository<K, V> {
     }
 
     public CompletableFuture<Void> deleteAsync(K id) {
-        return CompletableFuture.runAsync(() -> delete(id));
+        return CompletableFuture.runAsync(() -> delete(id), executor);
     }
 
     // ── QUERY BUILDER (bypasses cache – use for complex queries) ──────────────
@@ -274,18 +271,19 @@ public class CachedRepository<K, V> {
     // ── FLUSH (write-behind sync) ────────────────────────────────────────────
 
     /**
-     * Flushes all dirty cache entries to the database.
+     * Flushes all dirty cache entries to the database using batch upsert.
      * Safe to call manually at any time (e.g. on plugin disable).
+     * Called automatically by the background scheduler when using WRITE_BEHIND.
      */
     public void flush() {
         synchronized (flushLock) {
             Map<K, V> dirty = cache.getDirtyEntries();
             if (dirty.isEmpty()) return;
 
-            LOGGER.info("[CachedRepository] Flushing " + dirty.size() + " dirty entries to DB...");
+            List<V> entities = new ArrayList<>(dirty.values());
+            LOGGER.info("[CachedRepository] Flushing " + entities.size() + " dirty entries to DB...");
             try {
-                repo.insertAll(new ArrayList<>(dirty.values()));
-                // insertAll with upsert semantics – override if your DB supports it
+                repo.upsertAll(entities);
                 cache.markAllClean();
                 LOGGER.info("[CachedRepository] Flush complete.");
             } catch (Exception e) {
@@ -295,25 +293,8 @@ public class CachedRepository<K, V> {
         }
     }
 
-    /**
-     * Flush using upsert semantics (recommended for WRITE_BEHIND).
-     */
-    public void flushWithUpsert() {
-        synchronized (flushLock) {
-            Map<K, V> dirty = cache.getDirtyEntries();
-            if (dirty.isEmpty()) return;
-
-            LOGGER.info("[CachedRepository] Upserting " + dirty.size() + " dirty entries...");
-            for (V entity : dirty.values()) {
-                repo.upsert(entity);
-            }
-            cache.markAllClean();
-            LOGGER.info("[CachedRepository] Upsert flush complete.");
-        }
-    }
-
     public CompletableFuture<Void> flushAsync() {
-        return CompletableFuture.runAsync(this::flushWithUpsert);
+        return CompletableFuture.runAsync(this::flush, executor);
     }
 
     // ── CALLBACKS ────────────────────────────────────────────────────────────
@@ -333,7 +314,7 @@ public class CachedRepository<K, V> {
      */
     public void close() {
         if (writeStrategy == WriteStrategy.WRITE_BEHIND) {
-            flushWithUpsert();
+            flush();
         }
         flushScheduler.shutdownNow();
         cache.shutdown();
@@ -360,13 +341,13 @@ public class CachedRepository<K, V> {
         private final Database database;
         private final Class<V> entityClass;
         private WriteStrategy writeStrategy = WriteStrategy.WRITE_THROUGH;
-        private long flushIntervalMillis = 30_000L; // 30 s default for WRITE_BEHIND
+        private long flushIntervalMillis = 30_000L;
         private NotCache<K, V> cache;
+        private Executor executor = ForkJoinPool.commonPool();
 
         private Builder(Database database, Class<V> entityClass) {
             this.database = database;
             this.entityClass = entityClass;
-            // Default cache – can be overridden with .cache(...)
             this.cache = NotCache.<K, V>builder()
                     .maxSize(500)
                     .ttlMinutes(10)
@@ -394,9 +375,20 @@ public class CachedRepository<K, V> {
             return this;
         }
 
+        /**
+         * Sets the executor used for all *Async operations.
+         * Override to use a Folia/Paper-safe async scheduler:
+         * <pre>{@code
+         * .executor(r -> plugin.getServer().getAsyncScheduler().runNow(plugin, $ -> r.run()))
+         * }</pre>
+         */
+        public Builder<K, V> executor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
         public CachedRepository<K, V> build() {
             return new CachedRepository<>(this);
         }
     }
 }
-

--- a/src/main/java/dev/notmarra/notlib/database/DatabaseManager.java
+++ b/src/main/java/dev/notmarra/notlib/database/DatabaseManager.java
@@ -8,7 +8,10 @@ import dev.notmarra.notlib.database.repository.EntityRepository;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.logging.Logger;
 
 /**
@@ -62,16 +65,18 @@ public class DatabaseManager {
     private final int defaultCacheMaxSize;
     private final long defaultTtlMillis;
     private final CacheEvictionPolicy defaultEvictionPolicy;
+    private final Executor defaultExecutor;
 
     // ── CONSTRUCTOR ──────────────────────────────────────────────────────────
 
     private DatabaseManager(Builder b) {
-        this.database                 = b.database;
-        this.defaultWriteStrategy     = b.defaultWriteStrategy;
+        this.database                   = b.database;
+        this.defaultWriteStrategy       = b.defaultWriteStrategy;
         this.defaultFlushIntervalMillis = b.defaultFlushIntervalMillis;
-        this.defaultCacheMaxSize      = b.defaultCacheMaxSize;
-        this.defaultTtlMillis         = b.defaultTtlMillis;
-        this.defaultEvictionPolicy    = b.defaultEvictionPolicy;
+        this.defaultCacheMaxSize        = b.defaultCacheMaxSize;
+        this.defaultTtlMillis           = b.defaultTtlMillis;
+        this.defaultEvictionPolicy      = b.defaultEvictionPolicy;
+        this.defaultExecutor            = b.defaultExecutor;
     }
 
     // ── REGISTER ─────────────────────────────────────────────────────────────
@@ -104,6 +109,7 @@ public class DatabaseManager {
                 .writeStrategy(strategy)
                 .flushIntervalMillis(defaultFlushIntervalMillis)
                 .cache(cache)
+                .executor(defaultExecutor)
                 .build();
         repo.createTable();
         cachedRepos.put(entityClass, repo);
@@ -118,7 +124,8 @@ public class DatabaseManager {
      * caching adds no value.
      */
     public <V> EntityRepository<V> registerPlain(Class<V> entityClass) {
-        EntityRepository<V> repo = new EntityRepository<>(database, entityClass);
+        EntityRepository<V> repo = new EntityRepository<>(database, entityClass)
+                .withExecutor(defaultExecutor);
         repo.createTable();
         plainRepos.put(entityClass, repo);
         LOGGER.info("[DatabaseManager] Registered plain repo: " + entityClass.getSimpleName());
@@ -202,14 +209,26 @@ public class DatabaseManager {
 
     public static class Builder {
         private final Database database;
-        private WriteStrategy defaultWriteStrategy       = WriteStrategy.WRITE_THROUGH;
-        private long defaultFlushIntervalMillis          = 30_000L;
-        private int defaultCacheMaxSize                  = 500;
-        private long defaultTtlMillis                   = 10 * 60 * 1000L; // 10 min
+        private WriteStrategy defaultWriteStrategy        = WriteStrategy.WRITE_THROUGH;
+        private long defaultFlushIntervalMillis           = 30_000L;
+        private int defaultCacheMaxSize                   = 500;
+        private long defaultTtlMillis                     = 10 * 60 * 1000L;
         private CacheEvictionPolicy defaultEvictionPolicy = CacheEvictionPolicy.LRU;
+        private Executor defaultExecutor                  = ForkJoinPool.commonPool();
 
         private Builder(Database database) {
             this.database = database;
+        }
+
+        /** Copy constructor – used internally by NotPlugin.ManagedBuilder. */
+        protected Builder(Builder other) {
+            this.database                   = other.database;
+            this.defaultWriteStrategy       = other.defaultWriteStrategy;
+            this.defaultFlushIntervalMillis = other.defaultFlushIntervalMillis;
+            this.defaultCacheMaxSize        = other.defaultCacheMaxSize;
+            this.defaultTtlMillis           = other.defaultTtlMillis;
+            this.defaultEvictionPolicy      = other.defaultEvictionPolicy;
+            this.defaultExecutor            = other.defaultExecutor;
         }
 
         public Builder defaultWriteStrategy(WriteStrategy strategy) {
@@ -234,6 +253,17 @@ public class DatabaseManager {
 
         public Builder defaultEvictionPolicy(CacheEvictionPolicy policy) {
             this.defaultEvictionPolicy = policy; return this;
+        }
+
+        /**
+         * Sets the executor used for all *Async operations across every repository
+         * created by this manager. Override to use a Folia/Paper-safe async scheduler:
+         * <pre>{@code
+         * .executor(r -> plugin.getServer().getAsyncScheduler().runNow(plugin, $ -> r.run()))
+         * }</pre>
+         */
+        public Builder executor(Executor executor) {
+            this.defaultExecutor = executor; return this;
         }
 
         public DatabaseManager build() {

--- a/src/main/java/dev/notmarra/notlib/database/repository/EntityRepository.java
+++ b/src/main/java/dev/notmarra/notlib/database/repository/EntityRepository.java
@@ -13,19 +13,45 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
 public class EntityRepository<T> {
     private final Database database;
     private final EntityTable<T> table;
 
+    /**
+     * Executor used by all *Async methods.
+     * Defaults to ForkJoinPool.commonPool() – override via withExecutor() to use
+     * a Folia/Paper-safe async scheduler so DB callbacks never touch the wrong thread.
+     *
+     * <pre>{@code
+     * // Folia / Paper example:
+     * Executor foliaAsync = r -> plugin.getServer().getAsyncScheduler()
+     *         .runNow(plugin, $ -> r.run());
+     * EntityRepository<PlayerProfile> repo =
+     *         new EntityRepository<>(db, PlayerProfile.class).withExecutor(foliaAsync);
+     * }</pre>
+     */
+    private Executor executor = ForkJoinPool.commonPool();
+
     public EntityRepository(Database database, Class<T> clazz) {
         this.database = database;
         this.table = new EntityTable<>(clazz, database.getDialect());
     }
 
+    /**
+     * Returns a new repository instance that uses the given executor for all
+     * async operations. The original instance is unchanged.
+     */
+    public EntityRepository<T> withExecutor(Executor executor) {
+        this.executor = executor;
+        return this;
+    }
+
     public QueryBuilder<T> query() {
-        return new QueryBuilder<>(database, table, this);
+        return new QueryBuilder<>(database, table, this, executor);
     }
 
     public void createTable() {
@@ -47,7 +73,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Void> insertAsync(T entity) {
-        return CompletableFuture.runAsync(() -> insert(entity));
+        return CompletableFuture.runAsync(() -> insert(entity), executor);
     }
 
     // Bulk insert
@@ -75,7 +101,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Void> insertAllAsync(List<T> entities) {
-        return CompletableFuture.runAsync(() -> insertAll(entities));
+        return CompletableFuture.runAsync(() -> insertAll(entities), executor);
     }
 
     // ── UPSERT ───────────────────────────────────────────────────────────────
@@ -111,7 +137,54 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Void> upsertAsync(T entity) {
-        return CompletableFuture.runAsync(() -> upsert(entity));
+        return CompletableFuture.runAsync(() -> upsert(entity), executor);
+    }
+
+    // Bulk upsert
+    public void upsertAll(List<T> entities) {
+        if (entities.isEmpty()) return;
+        // Build the upsert SQL once and batch all entities
+        List<EntityTable.FieldColumn> cols = table.getColumns();
+        List<EntityTable.FieldColumn> nonPkCols = cols.stream()
+                .filter(fc -> !fc.annotation().primaryKey()).toList();
+
+        String columns = cols.stream().map(fc -> fc.annotation().name()).collect(Collectors.joining(", "));
+        String placeholders = cols.stream().map(fc -> "?").collect(Collectors.joining(", "));
+
+        String sql;
+        if (database.getDialect() == DbDialect.SQLITE) {
+            sql = "INSERT OR REPLACE INTO " + table.getTableName()
+                    + " (" + columns + ") VALUES (" + placeholders + ")";
+        } else {
+            String updateClause = nonPkCols.stream()
+                    .map(fc -> fc.annotation().name() + " = VALUES(" + fc.annotation().name() + ")")
+                    .collect(Collectors.joining(", "));
+            sql = "INSERT INTO " + table.getTableName()
+                    + " (" + columns + ") VALUES (" + placeholders + ")"
+                    + " ON DUPLICATE KEY UPDATE " + updateClause;
+        }
+
+        database.withConnection(conn -> {
+            conn.setAutoCommit(false);
+            try {
+                PreparedStatement stmt = conn.prepareStatement(sql);
+                for (T entity : entities) {
+                    bindValues(stmt, entity, cols);
+                    stmt.addBatch();
+                }
+                stmt.executeBatch();
+                conn.commit();
+            } catch (Exception e) {
+                conn.rollback();
+                throw e;
+            } finally {
+                conn.setAutoCommit(true);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> upsertAllAsync(List<T> entities) {
+        return CompletableFuture.runAsync(() -> upsertAll(entities), executor);
     }
 
     // ── FIND ─────────────────────────────────────────────────────────────────
@@ -133,7 +206,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Optional<T>> findByIdAsync(Object id) {
-        return CompletableFuture.supplyAsync(() -> findById(id));
+        return CompletableFuture.supplyAsync(() -> findById(id), executor);
     }
 
     public List<T> findAll() {
@@ -147,7 +220,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<List<T>> findAllAsync() {
-        return CompletableFuture.supplyAsync(this::findAll);
+        return CompletableFuture.supplyAsync(this::findAll, executor);
     }
 
     public boolean exists(Object id) {
@@ -155,7 +228,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Boolean> existsAsync(Object id) {
-        return CompletableFuture.supplyAsync(() -> exists(id));
+        return CompletableFuture.supplyAsync(() -> exists(id), executor);
     }
 
     // ── UPDATE ───────────────────────────────────────────────────────────────
@@ -182,7 +255,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Void> updateAsync(T entity) {
-        return CompletableFuture.runAsync(() -> update(entity));
+        return CompletableFuture.runAsync(() -> update(entity), executor);
     }
 
     // ── DELETE ───────────────────────────────────────────────────────────────
@@ -200,7 +273,7 @@ public class EntityRepository<T> {
     }
 
     public CompletableFuture<Void> deleteAsync(Object id) {
-        return CompletableFuture.runAsync(() -> delete(id));
+        return CompletableFuture.runAsync(() -> delete(id), executor);
     }
 
     // ── HELPERS ──────────────────────────────────────────────────────────────

--- a/src/main/java/dev/notmarra/notlib/database/repository/QueryBuilder.java
+++ b/src/main/java/dev/notmarra/notlib/database/repository/QueryBuilder.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 public class QueryBuilder<T> {
@@ -22,16 +23,18 @@ public class QueryBuilder<T> {
     private final Database database;
     private final EntityTable<T> table;
     private final EntityRepository<T> repository;
+    private final Executor executor;
 
     private final List<WhereClause> whereClauses = new ArrayList<>();
     private final List<OrderClause> orderClauses = new ArrayList<>();
     private Integer limit = null;
     private Integer offset = null;
 
-    public QueryBuilder(Database database, EntityTable<T> table, EntityRepository<T> repository) {
+    public QueryBuilder(Database database, EntityTable<T> table, EntityRepository<T> repository, Executor executor) {
         this.database = database;
         this.table = table;
         this.repository = repository;
+        this.executor = executor;
     }
 
     // ── WHERE ────────────────────────────────────────────────────────────────
@@ -182,18 +185,18 @@ public class QueryBuilder<T> {
     // ── ASYNC VARIANTS ───────────────────────────────────────────────────────
 
     public CompletableFuture<List<T>> findAllAsync() {
-        return CompletableFuture.supplyAsync(this::findAll);
+        return CompletableFuture.supplyAsync(this::findAll, executor);
     }
 
     public CompletableFuture<Optional<T>> findFirstAsync() {
-        return CompletableFuture.supplyAsync(this::findFirst);
+        return CompletableFuture.supplyAsync(this::findFirst, executor);
     }
 
     public CompletableFuture<Long> countAsync() {
-        return CompletableFuture.supplyAsync(this::count);
+        return CompletableFuture.supplyAsync(this::count, executor);
     }
 
     public CompletableFuture<Void> deleteAsync() {
-        return CompletableFuture.runAsync(this::delete);
+        return CompletableFuture.runAsync(this::delete, executor);
     }
 }

--- a/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
+++ b/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
@@ -6,6 +6,7 @@ import dev.notmarra.notlib.file.ManagedConfig;
 import dev.notmarra.notlib.chat.Colors;
 import dev.notmarra.notlib.chat.Text;
 import dev.notmarra.notlib.scheduler.Scheduler;
+import dev.notmarra.notlib.database.DatabaseManager;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -14,6 +15,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.Executor;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -57,6 +59,80 @@ public abstract class NotPlugin extends JavaPlugin {
     public Scheduler scheduler() { return scheduler; }
 
     public final String CONFIG_YML = "config.yml";
+
+    // -----------------------------------------------------------------------
+    // DatabaseManager – wired with the Folia-safe async executor automatically
+    // -----------------------------------------------------------------------
+
+    private final List<DatabaseManager> managedDatabases = new ArrayList<>();
+
+    /**
+     * Creates a {@link DatabaseManager.Builder} pre-configured with a
+     * Folia/Paper-safe async executor sourced from this plugin's scheduler.
+     * Call {@code .build()} on the returned builder and store the result yourself.
+     *
+     * <pre>{@code
+     * // in initPlugin():
+     * db = sqliteDatabase(getDataFolder(), "data").build();
+     * db.registerCached(PlayerProfile.class);
+     * }</pre>
+     *
+     * The returned manager is automatically closed (flushing all WRITE_BEHIND
+     * entries) when the plugin is disabled – you don't need to call db.close()
+     * manually, though doing so is safe.
+     */
+    public DatabaseManager.Builder sqliteDatabase(File dataFolder, String fileName) {
+        return new ManagedBuilder(DatabaseManager.sqlite(dataFolder, fileName)
+                .executor(foliaAsyncExecutor()));
+    }
+
+    /**
+     * Creates a {@link DatabaseManager.Builder} for MariaDB, pre-wired with
+     * the Folia-safe async executor.
+     */
+    public DatabaseManager.Builder mariaDatabase(String host, String port, String dbName,
+                                                 String user, String password) {
+        return new ManagedBuilder(DatabaseManager.mariadb(host, port, dbName, user, password)
+                .executor(foliaAsyncExecutor()));
+    }
+
+    /**
+     * Registers an externally-built {@link DatabaseManager} so it is
+     * automatically closed on plugin disable. Use this when you need full
+     * control over the builder but still want lifecycle management:
+     *
+     * <pre>{@code
+     * db = DatabaseManager.sqlite(...)
+     *         .executor(myCustomExecutor)
+     *         .build();
+     * manageDatabase(db);
+     * }</pre>
+     */
+    public void manageDatabase(DatabaseManager db) {
+        managedDatabases.add(db);
+    }
+
+    /** Returns the Folia-safe async {@link Executor} backed by this plugin's async scheduler. */
+    public Executor foliaAsyncExecutor() {
+        return r -> getServer().getAsyncScheduler().runNow(this, $ -> r.run());
+    }
+
+    /**
+     * Wraps {@link DatabaseManager.Builder} so that {@link #build()} automatically
+     * registers the result with this plugin's lifecycle.
+     */
+    private class ManagedBuilder extends DatabaseManager.Builder {
+        private ManagedBuilder(DatabaseManager.Builder delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public DatabaseManager build() {
+            DatabaseManager db = super.build();
+            managedDatabases.add(db);
+            return db;
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Listener / CommandGroup registration (unchanged)
@@ -271,6 +347,7 @@ public abstract class NotPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         onPluginDisable();
+        managedDatabases.forEach(DatabaseManager::close);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces improvements to asynchronous operations in the caching and repository layers by adding configurable executor support. The changes allow users to specify which executor is used for all async operations, making the codebase safer and more flexible for environments like Folia or Paper that require custom async scheduling. The default executor is now `ForkJoinPool.commonPool()`, but can be overridden at both the repository and manager levels.

Executor configuration and propagation:

* Added an `executor` field to `CachedRepository`, `EntityRepository`, and `DatabaseManager`, allowing all async operations to use a specified executor instead of the default. This makes it possible to use a scheduler compatible with Folia/Paper, avoiding thread safety issues. [[1]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eR57) [[2]](diffhunk://#diff-73e73d43b535c77d31c3b8390374ce295719adb15ee0d0873ab3f224ed7b946cR16-R54) [[3]](diffhunk://#diff-af4a067c2c2423503e89cb33b68ca3b1bf81b859d15b4565842c3538a67fea07R68)
* Updated all async methods in `CachedRepository` and `EntityRepository` to use the configured executor for their `CompletableFuture` operations. [[1]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL118-R115) [[2]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL128-R125) [[3]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL137-R134) [[4]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL160-R157) [[5]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL180-R177) [[6]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL203-R200) [[7]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL226-R223) [[8]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL237-R234) [[9]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL298-R297) [[10]](diffhunk://#diff-73e73d43b535c77d31c3b8390374ce295719adb15ee0d0873ab3f224ed7b946cL50-R76) [[11]](diffhunk://#diff-73e73d43b535c77d31c3b8390374ce295719adb15ee0d0873ab3f224ed7b946cL78-R104)

Builder enhancements for executor configuration:

* Added `executor` methods to the builders for `CachedRepository` and `DatabaseManager`, allowing users to set the executor during construction. Includes documentation and example usage for Folia/Paper-safe scheduling. [[1]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL363-L369) [[2]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eR378-L402) [[3]](diffhunk://#diff-af4a067c2c2423503e89cb33b68ca3b1bf81b859d15b4565842c3538a67fea07L208-R233) [[4]](diffhunk://#diff-af4a067c2c2423503e89cb33b68ca3b1bf81b859d15b4565842c3538a67fea07R258-R268)

Repository integration:

* Modified `EntityRepository` to propagate executor configuration via `withExecutor`, and updated `DatabaseManager` and `CachedRepository` to ensure repositories use the manager's executor setting. [[1]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL72-R69) [[2]](diffhunk://#diff-af4a067c2c2423503e89cb33b68ca3b1bf81b859d15b4565842c3538a67fea07R112) [[3]](diffhunk://#diff-af4a067c2c2423503e89cb33b68ca3b1bf81b859d15b4565842c3538a67fea07L121-R128) [[4]](diffhunk://#diff-73e73d43b535c77d31c3b8390374ce295719adb15ee0d0873ab3f224ed7b946cR16-R54)

Flush logic simplification:

* Removed the separate `flushWithUpsert` method and updated the `flush` method to use batch upsert via `repo.upsertAll`, simplifying cache flush semantics and ensuring async flush uses the configured executor. [[1]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL277-R286) [[2]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL298-R297) [[3]](diffhunk://#diff-9770c3bfa92e49577122b54f0a3fb0969bf8566bb56546843ede5d1730774e9eL336-R317)

These changes make async operations safer and more customizable, especially for plugin developers targeting modern Minecraft server platforms.