### PR TITLE
language manager

### DIFF
--- a/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
+++ b/src/main/java/dev/notmarra/notlib/extensions/NotPlugin.java
@@ -7,6 +7,7 @@ import dev.notmarra.notlib.chat.Colors;
 import dev.notmarra.notlib.chat.Text;
 import dev.notmarra.notlib.scheduler.Scheduler;
 import dev.notmarra.notlib.database.DatabaseManager;
+import dev.notmarra.notlib.language.LanguageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -115,6 +116,30 @@ public abstract class NotPlugin extends JavaPlugin {
     /** Returns the Folia-safe async {@link Executor} backed by this plugin's async scheduler. */
     public Executor foliaAsyncExecutor() {
         return r -> getServer().getAsyncScheduler().runNow(this, $ -> r.run());
+    }
+
+    // -----------------------------------------------------------------------
+    // LanguageManager – convenience factory pre-wired with the plugin's CFM
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates a {@link LanguageManager.Builder} pre-wired with this plugin's
+     * {@link dev.notmarra.notlib.file.ConfigFileManager} so language files are
+     * part of the same reload cycle as all other configs.
+     *
+     * <pre>{@code
+     * // in initPlugin():
+     * lang = languageManager()
+     *         .defaultLocale("en_US")
+     *         .seedFile("languages/en_US.yml")
+     *         .build();
+     *
+     * // Sending a message:
+     * lang.get("player.join").withPlayer(player).sendTo(player);
+     * }</pre>
+     */
+    public LanguageManager.Builder languageManager() {
+        return LanguageManager.builder(this).configFileManager(getCfm());
     }
 
     /**

--- a/src/main/java/dev/notmarra/notlib/language/LangMessage.java
+++ b/src/main/java/dev/notmarra/notlib/language/LangMessage.java
@@ -1,0 +1,153 @@
+package dev.notmarra.notlib.language;
+
+import dev.notmarra.notlib.chat.Text;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A lazy, fluent message builder returned by {@link LanguageManager#get(String)}
+ * and {@link LanguageManager#getFor(String, String)}.
+ *
+ * <p>The raw string is fetched from the active locale's YAML file and processed
+ * (prefix injected, placeholders replaced, legacy colors and MiniMessage parsed)
+ * only when {@link #build()} or one of the send methods is called.
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ * lang.get("player.join")
+ *     .withPlayer(player)
+ *     .with("%server%", "Survival")
+ *     .sendTo(player);
+ *
+ * // Per-player locale:
+ * lang.getFor(player, "error.no_permission")
+ *     .sendTo(player);
+ * }</pre>
+ */
+public class LangMessage {
+
+    private final LanguageManager manager;
+    private final String key;
+
+    /**
+     * Locale to resolve against. {@code null} means use the manager's default locale.
+     * Set by {@link LanguageManager#getFor}.
+     */
+    private final String locale;
+
+    private final Map<String, Object> replacements = new LinkedHashMap<>();
+
+    private Entity senderEntity;
+    private Entity targetEntity;
+
+    /** Default-locale constructor. */
+    LangMessage(LanguageManager manager, String key) {
+        this(manager, key, null);
+    }
+
+    /** Per-locale constructor. */
+    LangMessage(LanguageManager manager, String key, String locale) {
+        this.manager = manager;
+        this.key     = key;
+        this.locale  = locale;
+    }
+
+    // ── REPLACEMENTS ─────────────────────────────────────────────────────────
+
+    /**
+     * Adds a placeholder replacement.
+     *
+     * <p>The value can be a {@link String}, {@link Text}, {@link Component} or any
+     * object whose {@code toString()} will be used.
+     *
+     * @param placeholder e.g. {@code "%player%"}
+     * @param value       replacement value
+     */
+    public LangMessage with(String placeholder, Object value) {
+        replacements.put(placeholder, value);
+        return this;
+    }
+
+    /**
+     * Convenience overload – replaces {@code %player%} with the player's display name
+     * and registers built-in player placeholders ({@code %player_x%} etc.).
+     */
+    public LangMessage withPlayer(Player player) {
+        replacements.put("%player%", player.getName());
+        replacements.put("%player_name%", player.getName());
+        replacements.put("%player_display%", player.getDisplayName());
+        replacements.put("%player_x%", player.getLocation().getBlockX());
+        replacements.put("%player_y%", player.getLocation().getBlockY());
+        replacements.put("%player_z%", player.getLocation().getBlockZ());
+        replacements.put("%player_world%", player.getWorld().getName());
+        replacements.put("%player_health%", (int) player.getHealth());
+        replacements.put("%player_level%", player.getLevel());
+        this.senderEntity = player;
+        return this;
+    }
+
+    /**
+     * Convenience overload – registers {@code %target%} and built-in target placeholders.
+     */
+    public LangMessage withTarget(Player target) {
+        replacements.put("%target%", target.getName());
+        replacements.put("%target_name%", target.getName());
+        replacements.put("%target_display%", target.getDisplayName());
+        replacements.put("%target_x%", target.getLocation().getBlockX());
+        replacements.put("%target_y%", target.getLocation().getBlockY());
+        replacements.put("%target_z%", target.getLocation().getBlockZ());
+        replacements.put("%target_world%", target.getWorld().getName());
+        this.targetEntity = target;
+        return this;
+    }
+
+    // ── BUILD ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves the message and returns a fully built {@link Text} ready to send.
+     */
+    public Text build() {
+        String raw = locale == null
+                ? manager.resolve(key)
+                : manager.resolveIn(key, locale);
+
+        Text text = Text.of(raw);
+
+        for (Map.Entry<String, Object> entry : replacements.entrySet()) {
+            text.replace(entry.getKey(), entry.getValue());
+        }
+
+        if (senderEntity != null) text.withEntity(senderEntity);
+        if (targetEntity  != null) text.withTargetEntity(targetEntity);
+
+        return text;
+    }
+
+    /** Shortcut — returns the Adventure {@link Component} directly. */
+    public Component buildComponent() {
+        return build().build();
+    }
+
+    // ── SEND ─────────────────────────────────────────────────────────────────
+
+    /** Builds and sends the message to {@code audience}. */
+    public void sendTo(Audience audience) {
+        build().sendTo(audience);
+    }
+
+    /** Builds once and sends to every audience in the iterable. */
+    public void sendToAll(Iterable<? extends Audience> audiences) {
+        Component built = buildComponent();
+        for (Audience a : audiences) a.sendMessage(built);
+    }
+
+    /** Broadcasts the message to the entire server. */
+    public void broadcast() {
+        manager.getPlugin().getServer().broadcast(buildComponent());
+    }
+}

--- a/src/main/java/dev/notmarra/notlib/language/LanguageManager.java
+++ b/src/main/java/dev/notmarra/notlib/language/LanguageManager.java
@@ -1,0 +1,296 @@
+package dev.notmarra.notlib.language;
+
+import dev.notmarra.notlib.file.ConfigFileManager;
+import dev.notmarra.notlib.file.ConfigOptions;
+import dev.notmarra.notlib.file.ManagedConfig;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Manages localised messages loaded from YAML files in a watched directory.
+ *
+ * <h3>Directory layout</h3>
+ * <pre>
+ * plugins/MyPlugin/
+ *   languages/
+ *     en_US.yml   ← default / fallback locale
+ *     cs_CZ.yml
+ *     de_DE.yml
+ * </pre>
+ *
+ * <h3>YAML message file format</h3>
+ * <pre>{@code
+ * prefix: "<gray>[<aqua>MyPlugin</aqua>]</gray> "
+ *
+ * player:
+ *   join: "%prefix%<green>%player% joined the server!"
+ *   quit: "%prefix%<red>%player% left the server."
+ *   level_up: "%prefix%<yellow>%player% reached level %level%!"
+ *
+ * error:
+ *   no_permission: "%prefix%<red>You don't have permission."
+ *   player_only: "%prefix%<red>This command can only be used by players."
+ * }</pre>
+ *
+ * <h3>Minimal setup inside NotPlugin</h3>
+ * <pre>{@code
+ * private LanguageManager lang;
+ *
+ * @Override
+ * public void initPlugin() {
+ *     lang = LanguageManager.builder(this)
+ *             .directory("languages")
+ *             .defaultLocale("en_US")
+ *             .seedFile("languages/en_US.yml")
+ *             .build();
+ * }
+ *
+ * // Sending a message:
+ * lang.get("player.join")
+ *     .withPlayer(player)
+ *     .sendTo(player);
+ *
+ * // Switching locale per player:
+ * lang.setLocale(player.getUniqueId().toString(), "cs_CZ");
+ * }</pre>
+ *
+ * <h3>Prefix</h3>
+ * Every message value may contain {@code %prefix%} which is replaced with the
+ * {@code prefix} key from the active locale file. If the key is absent the
+ * replacement is an empty string — no NullPointerException.
+ */
+public class LanguageManager {
+
+    private static final Logger LOGGER = Logger.getLogger(LanguageManager.class.getName());
+
+    private static final String PREFIX_KEY     = "prefix";
+    private static final String PREFIX_HOLDER  = "%prefix%";
+
+    private final JavaPlugin plugin;
+    private final ConfigFileManager cfm;
+
+    private final String directory;
+    private final String defaultLocale;
+
+    /** Maps arbitrary entity IDs (player UUID string, "console", …) to locale codes. */
+    private final java.util.Map<String, String> localeMap = new java.util.HashMap<>();
+
+    // ── CONSTRUCTOR ──────────────────────────────────────────────────────────
+
+    private LanguageManager(Builder b) {
+        this.plugin        = b.plugin;
+        this.directory     = b.directory;
+        this.defaultLocale = normalise(b.defaultLocale);
+
+        // Wire into the plugin's ConfigFileManager so reloadAll() picks it up
+        this.cfm = b.cfm != null ? b.cfm : new ConfigFileManager(plugin);
+
+        ConfigOptions opts = ConfigOptions.builder()
+                .autoUpdate(false)          // user-maintained translation files
+                .copyFromResources(false)
+                .seedFile(b.seedFile)
+                .build();
+
+        cfm.watchDirectory(directory, opts);
+        cfm.loadAll();
+
+        if (getLocaleConfig(defaultLocale).isEmpty()) {
+            LOGGER.warning("[LanguageManager] Default locale '" + defaultLocale
+                    + "' not found in '" + directory + "/'. Messages will return their keys.");
+        }
+    }
+
+    // ── PUBLIC API ───────────────────────────────────────────────────────────
+
+    /**
+     * Returns a {@link LangMessage} for the given dot-separated key using the
+     * <em>default</em> locale.
+     *
+     * @param key dot-separated YAML path, e.g. {@code "player.join"}
+     */
+    public LangMessage get(String key) {
+        return new LangMessage(this, key);
+    }
+
+    /**
+     * Returns a {@link LangMessage} for the given key using the locale registered
+     * for {@code entityId}, falling back to the default locale if none is set.
+     *
+     * @param entityId arbitrary ID, typically a player's UUID string
+     * @param key      dot-separated YAML path
+     */
+    public LangMessage getFor(String entityId, String key) {
+        return new LangMessage(this, key, localeFor(entityId));
+    }
+
+    /**
+     * Returns a {@link LangMessage} for the given key using the locale registered
+     * for the given {@link org.bukkit.entity.Player}.
+     */
+    public LangMessage getFor(org.bukkit.entity.Player player, String key) {
+        return getFor(player.getUniqueId().toString(), key);
+    }
+
+    /**
+     * Registers a locale override for an entity.
+     *
+     * @param entityId arbitrary ID (player UUID string, "console", …)
+     * @param locale   locale code matching a file in the language directory,
+     *                 e.g. {@code "cs_CZ"} for {@code cs_CZ.yml}
+     */
+    public void setLocale(String entityId, String locale) {
+        localeMap.put(entityId, normalise(locale));
+    }
+
+    /** Removes the locale override for an entity (falls back to the default). */
+    public void clearLocale(String entityId) {
+        localeMap.remove(entityId);
+    }
+
+    /** Returns the active locale for an entity, or the default locale if none is set. */
+    public String localeFor(String entityId) {
+        return localeMap.getOrDefault(entityId, defaultLocale);
+    }
+
+    /** Returns all locale codes currently loaded (file stems without {@code .yml}). */
+    public java.util.Set<String> availableLocales() {
+        java.util.Set<String> locales = new java.util.LinkedHashSet<>();
+        for (ManagedConfig cfg : cfm.getDirectory(directory)) {
+            locales.add(stemOf(cfg.getFileName()));
+        }
+        return locales;
+    }
+
+    /** Reloads all language files from disk. */
+    public void reload() {
+        cfm.reloadDirectory(directory);
+        LOGGER.info("[LanguageManager] Reloaded " + availableLocales().size() + " locale(s).");
+    }
+
+    /** Returns the underlying plugin instance. */
+    public JavaPlugin getPlugin() { return plugin; }
+
+    // ── INTERNAL ─────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves a key against the default locale, injects the prefix, and returns
+     * the raw MiniMessage string. Used by {@link LangMessage#build()}.
+     */
+    String resolve(String key) {
+        return resolveIn(key, defaultLocale);
+    }
+
+    /**
+     * Resolves a key against a specific locale with default-locale fallback.
+     */
+    String resolveIn(String key, String locale) {
+        // 1. Try requested locale
+        Optional<FileConfiguration> yaml = getLocaleConfig(locale).map(ManagedConfig::yaml);
+        String raw = yaml.map(y -> y.getString(key)).orElse(null);
+
+        // 2. Fallback to default locale
+        if (raw == null && !locale.equals(defaultLocale)) {
+            Optional<FileConfiguration> fallback = getLocaleConfig(defaultLocale).map(ManagedConfig::yaml);
+            raw = fallback.map(y -> y.getString(key)).orElse(null);
+        }
+
+        // 3. Last resort – return the key itself so nothing explodes silently
+        if (raw == null) {
+            LOGGER.warning("[LanguageManager] Missing key '" + key + "' in locale '" + locale + "'.");
+            return key;
+        }
+
+        // Inject prefix
+        String prefix = yaml.map(y -> y.getString(PREFIX_KEY, "")).orElse("");
+        return raw.replace(PREFIX_HOLDER, prefix);
+    }
+
+    private Optional<ManagedConfig> getLocaleConfig(String locale) {
+        Collection<ManagedConfig> configs = cfm.getDirectory(directory);
+        return configs.stream()
+                .filter(c -> stemOf(c.getFileName()).equalsIgnoreCase(locale))
+                .findFirst();
+    }
+
+    /** {@code "languages/en_US.yml"} → {@code "en_US"} */
+    private static String stemOf(String fileName) {
+        String name = fileName.contains("/")
+                ? fileName.substring(fileName.lastIndexOf('/') + 1)
+                : fileName;
+        return name.endsWith(".yml")  ? name.substring(0, name.length() - 4)
+                : name.endsWith(".yaml") ? name.substring(0, name.length() - 5)
+                : name;
+    }
+
+    /** Normalises locale codes: {@code "en-us"} → {@code "en_US"} etc. */
+    private static String normalise(String locale) {
+        if (locale == null) return "en_US";
+        // Accept both "en_US" and "en-US" forms
+        return locale.replace('-', '_');
+    }
+
+    // ── BUILDER ──────────────────────────────────────────────────────────────
+
+    public static Builder builder(JavaPlugin plugin) {
+        return new Builder(plugin);
+    }
+
+    public static class Builder {
+        private final JavaPlugin plugin;
+        private String directory    = "languages";
+        private String defaultLocale = "en_US";
+        private String seedFile     = null;
+        private ConfigFileManager cfm = null;
+
+        private Builder(JavaPlugin plugin) {
+            this.plugin = plugin;
+        }
+
+        /**
+         * Directory (relative to the plugin data folder) that contains locale YAML files.
+         * Default: {@code "languages"}.
+         */
+        public Builder directory(String directory) {
+            this.directory = directory;
+            return this;
+        }
+
+        /**
+         * Locale code of the file used as the primary source and fallback.
+         * Default: {@code "en_US"} (expects {@code languages/en_US.yml}).
+         */
+        public Builder defaultLocale(String locale) {
+            this.defaultLocale = locale;
+            return this;
+        }
+
+        /**
+         * Resource path of an example file to copy into the language directory on
+         * first startup, giving server admins a template to translate.
+         *
+         * <p>Example: {@code .seedFile("languages/en_US.yml")}
+         */
+        public Builder seedFile(String resourcePath) {
+            this.seedFile = resourcePath;
+            return this;
+        }
+
+        /**
+         * Provide an existing {@link ConfigFileManager} to share (e.g. the one
+         * from {@code NotPlugin.getCfm()}). If omitted a new one is created internally.
+         */
+        public Builder configFileManager(ConfigFileManager cfm) {
+            this.cfm = cfm;
+            return this;
+        }
+
+        public LanguageManager build() {
+            return new LanguageManager(this);
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new language and localization system to the codebase, making it much easier to manage and deliver translated messages in plugins. The core of this update is the addition of a `LanguageManager` class for loading and managing locale files, and a `LangMessage` class for building and sending localized messages with placeholder support. Additionally, a convenience factory method is added to `NotPlugin` to simplify integration.

**New Localization System:**

* Added `LanguageManager` class for managing localized messages from YAML files, supporting per-entity locales, prefix injection, and integration with the plugin's configuration reload cycle. Includes a builder for flexible setup.
* Introduced `LangMessage` class, a fluent message builder supporting placeholder replacement (including built-in player/target placeholders), lazy message resolution, and multiple send options (to players, audiences, or broadcast).

**Integration with Plugin:**

* Added a `languageManager()` factory method to `NotPlugin` that returns a pre-wired `LanguageManager.Builder`, ensuring language files participate in the plugin's reload cycle.
* Imported `LanguageManager` in `NotPlugin.java` to enable the new factory method.